### PR TITLE
Add uint256 fuzz test vs TTMath

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
+# ignore all executable files
+*
+!*.*
+!*/
+*.exe
+
 nimcache/
 build/

--- a/stint.nimble
+++ b/stint.nimble
@@ -7,8 +7,8 @@ srcDir        = "src"
 
 ### Dependencies
 
-# TODO remove test only requirements: https://github.com/nim-lang/nimble/issues/482
-requires "nim >= 0.18", "https://github.com/alehander42/nim-quicktest >= 0.18.0"
+# TODO remove quicktest and ttmath test only requirements: https://github.com/nim-lang/nimble/issues/482
+requires "nim >= 0.18", "https://github.com/alehander42/nim-quicktest >= 0.18.0", "https://github.com/status-im/nim-ttmath"
 
 proc test(name: string, lang: string = "c") =
   if not dirExists "build":
@@ -34,7 +34,7 @@ task test_debug, "Run all tests - test implementation (StUint[64] = 2x uint32":
 task test_release, "Run all tests - prod implementation (StUint[64] = uint64":
   test "all_tests"
 
-task test_property_debug, "Run random tests (normal mode) - test implementation (StUint[64] = 2x uint32)":
+task test_property_debug, "Run random tests (debug mode) - test implementation (StUint[64] = 2x uint32)":
   requires "quicktest > 0.0.8"
   switch("define", "mpint_test")
   test "property_based"
@@ -45,13 +45,13 @@ task test_property_release, "Run random tests (release mode) - test implementati
   switch("define", "release")
   test "property_based"
 
-task test_property_uint256_debug, "Run random tests (normal mode) vs TTMath on Uint256":
+task test_property_uint256_debug, "Run random tests Uint256 (debug mode) vs TTMath (StUint[256] = 8 x uint32)":
   # TODO: another reference implementation?
   # Note that currently importing both Stint and TTMath will crash the compiler for unknown reason.
   requires "quicktest > 0.0.8"
   test "property_based", "cpp"
 
-task test_property_uint256_release, "Run random tests (release mode) vs TTMath on Uint256":
+task test_property_uint256_release, "Run random tests Uint256 (release mode) vs TTMath (StUint[256] = 4 x uint64)":
   # TODO: another reference implementation?
   # Note that currently importing both Stint and TTMath will crash the compiler for unknown reason.
   requires "quicktest > 0.0.8"
@@ -65,4 +65,5 @@ task test, "Run all tests - test and production implementation":
   exec "nimble test_release"
   exec "nimble test_property_debug"
   exec "nimble test_property_release"
-  # TODO: ttmath tests, but importing both together raises illegal storage access
+  exec "nimble test_property_uint256_debug"
+  exec "nimble test_property_uint256_release"

--- a/tests/property_based.nim
+++ b/tests/property_based.nim
@@ -14,9 +14,9 @@ const itercount = 1000
 suite "Property-based testing (testing with random inputs) - uint64 on 64-bit / uint32 on 32-bit":
 
   when defined(release):
-    echo "Testing in release mode with " & $itercount & " random tests for each proc."
+    echo "Testing in release mode with " & $itercount & " random tests for each proc. (StUint[64] = uint64)"
   else:
-    echo "Testing in normal (non-release) mode " & $itercount & " random tests for each proc."
+    echo "Testing in debug mode " & $itercount & " random tests for each proc. (StUint[64] = 2x uint32)"
 
   let hi = 1'u shl (sizeof(uint)*7)
 

--- a/tests/property_based_uint256.nim
+++ b/tests/property_based_uint256.nim
@@ -14,7 +14,7 @@ import ../src/stint, unittest, quicktest, ttmath_compat
 
 const itercount = 1000
 
-suite "Property-based testing (testing with random inputs) - uint64 on 64-bit / uint32 on 32-bit":
+suite "Property-based testing (testing with random inputs) of Uint256":
 
   when defined(release):
     echo "Testing in release mode. (StUint[256] = 4 x uint64)"

--- a/tests/property_based_uint256.nim
+++ b/tests/property_based_uint256.nim
@@ -17,9 +17,9 @@ const itercount = 1000
 suite "Property-based testing (testing with random inputs) - uint64 on 64-bit / uint32 on 32-bit":
 
   when defined(release):
-    echo "Testing in release mode"
+    echo "Testing in release mode. (StUint[256] = 4 x uint64)"
   else:
-    echo "Testing in normal (non-release) mode"
+    echo "Testing in debug mode. (StUint[256] = 8 x uint32)"
 
   let hi = 1'u shl (sizeof(uint)*7)
 

--- a/tests/property_based_uint256.nim
+++ b/tests/property_based_uint256.nim
@@ -10,7 +10,7 @@
 
 # Requires "https://github.com/status-im/nim-ttmath#master"
 # Note that currently importing both Stint and TTMath will crash the compiler for unknown reason
-import ../src/stint, unittest, quicktest, ttmath
+import ../src/stint, unittest, quicktest, ttmath_compat
 
 const itercount = 1000
 
@@ -36,8 +36,8 @@ suite "Property-based testing (testing with random inputs) - uint64 on 64-bit / 
       x = [x0, x1, x2, x3]
       y = [y0, y1, y2, y3]
 
-      ttm_x = cast[ttmath.UInt256](x)
-      ttm_y = cast[ttmath.UInt256](y)
+      ttm_x = x.asTT
+      ttm_y = y.asTT
       mp_x  = cast[StUint[256]](x)
       mp_y  = cast[StUint[256]](y)
 
@@ -45,8 +45,7 @@ suite "Property-based testing (testing with random inputs) - uint64 on 64-bit / 
       ttm_z = ttm_x or ttm_y
       mp_z  = mp_x  or mp_y
 
-    check(cast[array[4, uint64]](ttm_z) == cast[array[4, uint64]](mp_z))
-
+    check ttm_z.asSt == mp_z
 
   quicktest "`and`", itercount do(x0: uint(min=0, max=hi),
                                 x1: uint(min=0, max=hi),
@@ -61,8 +60,8 @@ suite "Property-based testing (testing with random inputs) - uint64 on 64-bit / 
       x = [x0, x1, x2, x3]
       y = [y0, y1, y2, y3]
 
-      ttm_x = cast[ttmath.UInt256](x)
-      ttm_y = cast[ttmath.UInt256](y)
+      ttm_x = x.asTT
+      ttm_y = y.asTT
       mp_x  = cast[StUint[256]](x)
       mp_y  = cast[StUint[256]](y)
 
@@ -70,7 +69,7 @@ suite "Property-based testing (testing with random inputs) - uint64 on 64-bit / 
       ttm_z = ttm_x and ttm_y
       mp_z  = mp_x  and mp_y
 
-    check(cast[array[4, uint64]](ttm_z) == cast[array[4, uint64]](mp_z))
+    check ttm_z.asSt == mp_z
 
   quicktest "`xor`", itercount do(x0: uint(min=0, max=hi),
                                 x1: uint(min=0, max=hi),
@@ -85,8 +84,8 @@ suite "Property-based testing (testing with random inputs) - uint64 on 64-bit / 
       x = [x0, x1, x2, x3]
       y = [y0, y1, y2, y3]
 
-      ttm_x = cast[ttmath.UInt256](x)
-      ttm_y = cast[ttmath.UInt256](y)
+      ttm_x = x.asTT
+      ttm_y = y.asTT
       mp_x  = cast[StUint[256]](x)
       mp_y  = cast[StUint[256]](y)
 
@@ -94,7 +93,7 @@ suite "Property-based testing (testing with random inputs) - uint64 on 64-bit / 
       ttm_z = ttm_x xor ttm_y
       mp_z  = mp_x  xor mp_y
 
-    check(cast[array[4, uint64]](ttm_z) == cast[array[4, uint64]](mp_z))
+    check ttm_z.asSt == mp_z
 
   # Not defined for ttmath
   # quicktest "`not`", itercount do(x0: uint(min=0, max=hi),
@@ -128,8 +127,8 @@ suite "Property-based testing (testing with random inputs) - uint64 on 64-bit / 
       x = [x0, x1, x2, x3]
       y = [y0, y1, y2, y3]
 
-      ttm_x = cast[ttmath.UInt256](x)
-      ttm_y = cast[ttmath.UInt256](y)
+      ttm_x = x.asTT
+      ttm_y = y.asTT
       mp_x  = cast[StUint[256]](x)
       mp_y  = cast[StUint[256]](y)
 
@@ -153,8 +152,8 @@ suite "Property-based testing (testing with random inputs) - uint64 on 64-bit / 
       x = [x0, x1, x2, x3]
       y = [y0, y1, y2, y3]
 
-      ttm_x = cast[ttmath.UInt256](x)
-      ttm_y = cast[ttmath.UInt256](y)
+      ttm_x = x.asTT
+      ttm_y = y.asTT
       mp_x  = cast[StUint[256]](x)
       mp_y  = cast[StUint[256]](y)
 
@@ -177,8 +176,8 @@ suite "Property-based testing (testing with random inputs) - uint64 on 64-bit / 
       x = [x0, x1, x2, x3]
       y = [y0, y1, y2, y3]
 
-      ttm_x = cast[ttmath.UInt256](x)
-      ttm_y = cast[ttmath.UInt256](y)
+      ttm_x = x.asTT
+      ttm_y = y.asTT
       mp_x  = cast[StUint[256]](x)
       mp_y  = cast[StUint[256]](y)
 
@@ -186,7 +185,7 @@ suite "Property-based testing (testing with random inputs) - uint64 on 64-bit / 
       ttm_z = ttm_x + ttm_y
       mp_z  = mp_x  + mp_y
 
-    check(cast[array[4, uint64]](ttm_z) == cast[array[4, uint64]](mp_z))
+    check ttm_z.asSt == mp_z
 
   quicktest "`-`", itercount do(x0: uint(min=0, max=hi),
                                 x1: uint(min=0, max=hi),
@@ -201,8 +200,8 @@ suite "Property-based testing (testing with random inputs) - uint64 on 64-bit / 
       x = [x0, x1, x2, x3]
       y = [y0, y1, y2, y3]
 
-      ttm_x = cast[ttmath.UInt256](x)
-      ttm_y = cast[ttmath.UInt256](y)
+      ttm_x = x.asTT
+      ttm_y = y.asTT
       mp_x  = cast[StUint[256]](x)
       mp_y  = cast[StUint[256]](y)
 
@@ -210,7 +209,7 @@ suite "Property-based testing (testing with random inputs) - uint64 on 64-bit / 
       ttm_z = ttm_x - ttm_y
       mp_z  = mp_x  - mp_y
 
-    check(cast[array[4, uint64]](ttm_z) == cast[array[4, uint64]](mp_z))
+    check ttm_z.asSt == mp_z
 
   quicktest "`*`", itercount do(x0: uint(min=0, max=hi),
                                 x1: uint(min=0, max=hi),
@@ -225,8 +224,8 @@ suite "Property-based testing (testing with random inputs) - uint64 on 64-bit / 
       x = [x0, x1, x2, x3]
       y = [y0, y1, y2, y3]
 
-      ttm_x = cast[ttmath.UInt256](x)
-      ttm_y = cast[ttmath.UInt256](y)
+      ttm_x = x.asTT
+      ttm_y = y.asTT
       mp_x  = cast[StUint[256]](x)
       mp_y  = cast[StUint[256]](y)
 
@@ -234,7 +233,7 @@ suite "Property-based testing (testing with random inputs) - uint64 on 64-bit / 
       ttm_z = ttm_x * ttm_y
       mp_z  = mp_x  * mp_y
 
-    check(cast[array[4, uint64]](ttm_z) == cast[array[4, uint64]](mp_z))
+    check ttm_z.asSt == mp_z
 
   quicktest "`shl`", itercount do(x0: uint(min=0, max=hi),
                                 x1: uint(min=0, max=hi),
@@ -245,14 +244,14 @@ suite "Property-based testing (testing with random inputs) - uint64 on 64-bit / 
     let
       x = [x0, x1, x2, x3]
 
-      ttm_x = cast[ttmath.UInt256](x)
+      ttm_x = x.asTT
       mp_x  = cast[StUint[256]](x)
 
     let
       ttm_z = ttm_x shl y.uint
       mp_z  = mp_x  shl y
 
-    check(cast[array[4, uint64]](ttm_z) == cast[array[4, uint64]](mp_z))
+    check ttm_z.asSt == mp_z
 
   quicktest "`shr`", itercount do(x0: uint(min=0, max=hi),
                                 x1: uint(min=0, max=hi),
@@ -263,14 +262,14 @@ suite "Property-based testing (testing with random inputs) - uint64 on 64-bit / 
     let
       x = [x0, x1, x2, x3]
 
-      ttm_x = cast[ttmath.UInt256](x)
+      ttm_x = x.asTT
       mp_x  = cast[StUint[256]](x)
 
     let
       ttm_z = ttm_x shr y.uint
       mp_z  = mp_x  shr y
 
-    check(cast[array[4, uint64]](ttm_z) == cast[array[4, uint64]](mp_z))
+    check ttm_z.asSt == mp_z
 
   quicktest "`mod`", itercount do(x0: uint(min=0, max=hi),
                                 x1: uint(min=0, max=hi),
@@ -285,8 +284,8 @@ suite "Property-based testing (testing with random inputs) - uint64 on 64-bit / 
       x = [x0, x1, x2, x3]
       y = [y0, y1, y2, y3]
 
-      ttm_x = cast[ttmath.UInt256](x)
-      ttm_y = cast[ttmath.UInt256](y)
+      ttm_x = x.asTT
+      ttm_y = y.asTT
       mp_x  = cast[StUint[256]](x)
       mp_y  = cast[StUint[256]](y)
 
@@ -307,11 +306,12 @@ suite "Property-based testing (testing with random inputs) - uint64 on 64-bit / 
       x = [x0, x1, x2, x3]
       y = [y0, y1, y2, y3]
 
-      ttm_x = cast[ttmath.UInt256](x)
-      ttm_y = cast[ttmath.UInt256](y)
+      ttm_x = x.asTT
+      ttm_y = y.asTT
       mp_x  = cast[StUint[256]](x)
       mp_y  = cast[StUint[256]](y)
 
     let
       ttm_z = ttm_x div ttm_y
       mp_z  = mp_x  div mp_y
+

--- a/tests/ttmath_compat.nim
+++ b/tests/ttmath_compat.nim
@@ -1,0 +1,19 @@
+import ../src/stint, ttmath
+export ttmath
+
+template asSt*(val: UInt): auto =
+  type TargetType = StUint[val.NumBits]
+  cast[ptr TargetType](unsafeAddr val)[]
+
+template asSt*(val: Int): auto =
+  type TargetType = StInt[val.NumBits]
+  cast[ptr TargetType](unsafeAddr val)[]
+
+template asTT*[N: static[int]](arr: array[N, uint]): auto =
+  type TargetType = UInt[N * 64]
+  cast[ptr TargetType](unsafeAddr arr[0])[]
+
+template asTT*[N: static[int]](arr: array[N, int]): auto =
+  type TargetType = Int[N * 64]
+  cast[ptr TargetType](unsafeAddr arr[0])[]
+


### PR DESCRIPTION
This adds fuzz testing vs TTMath.

It requires the latest Nimbus patch: https://github.com/status-im/Nim/commit/60db1a899c3b15df677092e90be982bf6a60a9fd

There is still a C++ only SIGSEGV with nil string/json (?):
```
<...>/.nimble/pkgs/quicktest-0.18.0/quicktest.nim(414, 47) Hint: simpleGetOrDefault(parseJson(serialized397017), "args") --> 'getOrDefault(parseJson(serialized397017), "args")' [Pattern]
SIGSEGV: Illegal storage access. (Attempt to read from nil?)
```

Also unfortunately, to add this to CI, Stint must require quicktest and ttmath, though if they are not used it shouldn't force C++ compilation. Feature request here: https://github.com/nim-lang/nimble/issues/482.