### PR TITLE
Restrict pragma: use VCC + GCC + LLVM compatible syntax

### DIFF
--- a/src/io.nim
+++ b/src/io.nim
@@ -262,7 +262,7 @@ func dumpHex*(x: Stint or StUint, order: static[Endianness]): string =
     hexChars = "0123456789abcdef"
     size = getSize(x.data) div 8
 
-  {.pragma: restrict, codegenDecl: "$# __restrict__ $#".}
+  {.pragma: restrict, codegenDecl: "$# __restrict $#".}
   let bytes {.restrict.}= cast[ptr array[size, byte]](x.unsafeaddr)
 
   result = newString(2*size)

--- a/src/private/as_signed_words.nim
+++ b/src/private/as_signed_words.nim
@@ -133,7 +133,7 @@ macro asSignedWordsZip*[T](
     # if we have multiple iterations to do
     if system.cpuEndian == bigEndian:
       result = quote do:
-        {.pragma: restrict, codegenDecl: "$# __restrict__ $#".}
+        {.pragma: restrict, codegenDecl: "$# __restrict $#".}
         let
           `next_x`{.restrict.} = cast[ptr `optim_type`](`x`.unsafeaddr)
           `next_y`{.restrict.} = cast[ptr `optim_type`](`y`.unsafeaddr)
@@ -143,7 +143,7 @@ macro asSignedWordsZip*[T](
     else:
       # Little-Endian, iteration in reverse
       result = quote do:
-        {.pragma: restrict, codegenDecl: "$# __restrict__ $#".}
+        {.pragma: restrict, codegenDecl: "$# __restrict $#".}
         let
           `next_x`{.restrict.} = cast[ptr `optim_type`](`x`.unsafeaddr)
           `next_y`{.restrict.} = cast[ptr `optim_type`](`y`.unsafeaddr)

--- a/src/private/as_words.nim
+++ b/src/private/as_words.nim
@@ -159,7 +159,7 @@ macro asWordsZip*(x, y: UintImpl or IntImpl, ignoreEndianness: static[bool], loo
   else:
     if ignoreEndianness or system.cpuEndian == bigEndian:
       result = quote do:
-        {.pragma: restrict, codegenDecl: "$# __restrict__ $#".}
+        {.pragma: restrict, codegenDecl: "$# __restrict $#".}
         let
           `inner_x`{.restrict.} = cast[ptr `optim_type`](`x`.unsafeaddr)
           `inner_y`{.restrict.} = cast[ptr `optim_type`](`y`.unsafeaddr)
@@ -168,7 +168,7 @@ macro asWordsZip*(x, y: UintImpl or IntImpl, ignoreEndianness: static[bool], loo
     else:
       # Little-Endian, iteration in reverse
       result = quote do:
-        {.pragma: restrict, codegenDecl: "$# __restrict__ $#".}
+        {.pragma: restrict, codegenDecl: "$# __restrict $#".}
         let
           `inner_x`{.restrict.} = cast[ptr `optim_type`](`x`.unsafeaddr)
           `inner_y`{.restrict.} = cast[ptr `optim_type`](`y`.unsafeaddr)
@@ -224,7 +224,7 @@ macro m_asWordsZip*[T: UintImpl or IntImpl](m: var T, x: T,
   else:
     if ignoreEndianness or system.cpuEndian == bigEndian:
       result = quote do:
-        {.pragma: restrict, codegenDecl: "$# __restrict__ $#".}
+        {.pragma: restrict, codegenDecl: "$# __restrict $#".}
         let
           `inner_m`{.restrict.} = cast[ptr `optim_type`](`m`.addr)
           `inner_x`{.restrict.} = cast[ptr `optim_type`](`x`.unsafeaddr)
@@ -233,7 +233,7 @@ macro m_asWordsZip*[T: UintImpl or IntImpl](m: var T, x: T,
     else:
       # Little-Endian, iteration in reverse
       result = quote do:
-        {.pragma: restrict, codegenDecl: "$# __restrict__ $#".}
+        {.pragma: restrict, codegenDecl: "$# __restrict $#".}
         let
           `inner_m`{.restrict.} = cast[ptr `optim_type`](`m`.addr)
           `inner_x`{.restrict.} = cast[ptr `optim_type`](`x`.unsafeaddr)
@@ -298,7 +298,7 @@ macro m_asWordsZip*[T: UintImpl or IntImpl](m: var T, x, y: T,
   else:
     if ignoreEndianness or system.cpuEndian == bigEndian:
       result = quote do:
-        {.pragma: restrict, codegenDecl: "$# __restrict__ $#".}
+        {.pragma: restrict, codegenDecl: "$# __restrict $#".}
         let
           `inner_m`{.restrict.} = cast[ptr `optim_type`](`m`.addr)
           `inner_x`{.restrict.} = cast[ptr `optim_type`](`x`.unsafeaddr)
@@ -308,7 +308,7 @@ macro m_asWordsZip*[T: UintImpl or IntImpl](m: var T, x, y: T,
     else:
       # Little-Endian, iteration in reverse
       result = quote do:
-        {.pragma: restrict, codegenDecl: "$# __restrict__ $#".}
+        {.pragma: restrict, codegenDecl: "$# __restrict $#".}
         let
           `inner_m`{.restrict.} = cast[ptr `optim_type`](`m`.addr)
           `inner_x`{.restrict.} = cast[ptr `optim_type`](`x`.unsafeaddr)


### PR DESCRIPTION
We can't use plain restrict, as that is not a C++ keyword and would prevent us compiling to C++ in the future (not that we actually want to).

`__restrict__` is not understood by VCC
`__restrict` should be understood by all compilers.