### PR TITLE
Add optional mixed types syntactic sugar

### DIFF
--- a/stint/lenient_stint.nim
+++ b/stint/lenient_stint.nim
@@ -68,12 +68,3 @@ make_mixed_types_ops(`==`, bool, BothSigned, switchInputs = true)
 make_mixed_types_ops(`or`, InputType, BothSigned, switchInputs = true)
 make_mixed_types_ops(`and`, InputType, BothSigned, switchInputs = true)
 make_mixed_types_ops(`xor`, InputType, BothSigned, switchInputs = true)
-
-# Specialization / fast path for comparison to zero
-template mtoIsZero*{a == 0}(a: StUint or Stint): bool = a.isZero
-template mtoIsZero*{0 == a}(a: StUint or Stint): bool = a.isZero
-
-template mtoIsNeg*{a < 0}(a: Stint): bool = a.isNegative
-template mtoIsNegOrZero*{a <= 0}(a: Stint): bool = a.isZero or a.isNegative
-template mtoIsPos*{a > 0}(a: Stint): bool = not(a.isZero or a.isNegative)
-template mtoIsPosOrZero*{a >= 0}(a: Stint): bool = not a.isNegative

--- a/stint/mixed_types_ops.nim
+++ b/stint/mixed_types_ops.nim
@@ -1,0 +1,79 @@
+# Stint
+# Copyright 2018 Status Research & Development GmbH
+# Licensed under either of
+#
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+#
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+## This file provide optional syntactic sugar to work with operations on mixed precision integers (for example uint256 + uint)
+
+import ./int_public, ./uint_public, macros
+
+type Signedness = enum
+  BothSigned, IntOnly, UintOnly
+
+macro make_mixed_types_ops(op: untyped, ResultTy: untyped, sign: static[Signedness], switchInputs: static[bool]): untyped =
+  # ResultTy must be "InputType" or a real type like bool
+
+  let isInputType = eqIdent(ResultTy, "InputType")
+  result = newStmtList()
+
+  if sign != IntOnly:
+    let ResultTy =  if not isInputType: ResultTy
+                    else: nnkBracketExpr.newTree(
+                      newIdentNode("StUint"),
+                      newIdentNode("bits")
+                    )
+
+    result.add quote do:
+      proc `op`*[bits: static[int]](a: Stuint[bits], b: SomeInteger): `ResultTy` {.inline.}=
+        `op`(a, b.stuint(bits))
+
+    if switchInputs:
+      result.add quote do:
+        proc `op`*[bits: static[int]](a: SomeInteger, b: Stuint[bits]): `ResultTy` {.inline.}=
+          `op`(a.stuint(bits), b)
+
+  if sign != UintOnly:
+    let ResultTy =  if not isInputType: ResultTy
+                    else: nnkBracketExpr.newTree(
+                      newIdentNode("StInt"),
+                      newIdentNode("bits")
+                    )
+
+    result.add quote do:
+      proc `op`*[bits: static[int]](a: Stint[bits], b: SomeInteger): `ResultTy` {.inline.}=
+        `op`(a, b.stuint(bits))
+
+    if switchInputs:
+      result.add quote do:
+        proc `op`*[bits: static[int]](a: SomeInteger, b: Stint[bits]): `ResultTy` {.inline.}=
+          `op`(a.stuint(bits), b)
+
+make_mixed_types_ops(`+`, InputType, BothSigned, switchInputs = true)
+make_mixed_types_ops(`+=`, InputType, BothSigned, switchInputs = false)
+make_mixed_types_ops(`-`, InputType, BothSigned, switchInputs = true)
+make_mixed_types_ops(`-=`, InputType, BothSigned, switchInputs = false)
+make_mixed_types_ops(`*`, InputType, BothSigned, switchInputs = true)
+make_mixed_types_ops(`div`, InputType, BothSigned, switchInputs = false)
+make_mixed_types_ops(`mod`, InputType, BothSigned, switchInputs = false)
+make_mixed_types_ops(divmod, InputType, BothSigned, switchInputs = false)
+
+make_mixed_types_ops(`<`, bool, BothSigned, switchInputs = true)
+make_mixed_types_ops(`<=`, bool, BothSigned, switchInputs = true)
+make_mixed_types_ops(`==`, bool, BothSigned, switchInputs = true)
+
+make_mixed_types_ops(`or`, InputType, BothSigned, switchInputs = true)
+make_mixed_types_ops(`and`, InputType, BothSigned, switchInputs = true)
+make_mixed_types_ops(`xor`, InputType, BothSigned, switchInputs = true)
+
+# Specialization / fast path for comparison to zero
+template mtoIsZero*{a == 0}(a: StUint or Stint): bool = a.isZero
+template mtoIsZero*{0 == a}(a: StUint or Stint): bool = a.isZero
+
+template mtoIsNeg*{a < 0}(a: Stint): bool = a.isNegative
+template mtoIsNegOrZero*{a <= 0}(a: Stint): bool = a.isZero or a.isNegative
+template mtoIsPos*{a > 0}(a: Stint): bool = not(a.isZero or a.isNegative)
+template mtoIsPosOrZero*{a >= 0}(a: Stint): bool = not a.isNegative


### PR DESCRIPTION
Solve #15 

Introduce optional mixed types syntactic sugar.

The goal is to keep a natural syntax as much as possible and avoid having conversion everywhere when working with mixed uint256, int and uint in a codebase for example.

The file must be explicitly imported with `import stint/mixed_types_ops` so that when strong static typing is preferred or for debugging, conversions are required to be explicit.