### PR TITLE
Fix multiplication on 32 bit systems

### DIFF
--- a/stint/private/uint_mul.nim
+++ b/stint/private/uint_mul.nim
@@ -48,7 +48,7 @@ func extPrecAddMul[T: uint8 or uint16 or uint32](result: var UintImpl[T], x, y: 
 template extPrecMulImpl(result: var UintImpl[uint64], op: untyped, u, v: uint64) =
   const
     p = 64 div 2
-    base = 1 shl p
+    base: uint64 = 1 shl p
 
   var
     x0, x1, x2, x3: uint64


### PR DESCRIPTION
Currently on 32 bit systems the follow code doesn't perform as expected:

```
import stint

proc doTest(stintType: typedesc) =
  var
    a = fromHex(stintType, "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
    b = fromHex(stintType, "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
    c = a * b
  echo c.toHex

# expected 3fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000000000000001
# actual   3ffffffffffffffffffffffdfffffffffffffffcfffffffffffffffbfffffffefffffffcfffffffffffffffdffffffffffffffff000000000000000000000001
doTest(StUInt[2048])
# expected 0000000000000000000000000000000000000000000000000000000000000001
# actual   fffffffcfffffffffffffffdffffffffffffffff000000000000000000000001
doTest(UInt256)
```
This small PR allows `stint` to perform correctly in 32 bit.