### PR TITLE
Reenable stint test [WIP, will probably be superceded]

### DIFF
--- a/stint/private/datatypes.nim
+++ b/stint/private/datatypes.nim
@@ -100,7 +100,7 @@ template checkDiv2(bits: static[int]): untyped =
     doAssert bits >= 8, "The number of bits in a should be greater or equal to 8"
   bits div 2
 
-when defined(mpint_test): # TODO stint_test
+when defined(stint_test): # TODO stint_test
   template uintImpl*(bits: static[int]): untyped =
     # Test version, StUint[64] = 2 uint32. Test the logic of the library
 

--- a/stint/private/int_bitwise_ops.nim
+++ b/stint/private/int_bitwise_ops.nim
@@ -60,7 +60,7 @@ func `shl`*(x: IntImpl, y: SomeInteger): IntImpl {.inline.}=
     result.hi = convert[HiType](x.lo shl (y - halfSize))
 
 template createShr(name, operator: untyped) =
-  template name(x, y: SomeInteger): auto =
+  template name(x, y: distinct SomeInteger): auto =
     operator(x, y)
 
   func name*(x: IntImpl, y: SomeInteger): IntImpl {.inline.}=

--- a/tests/test_io.nim
+++ b/tests/test_io.nim
@@ -85,6 +85,15 @@ suite "Testing input and output procedures":
     # TODO: negative hex
 
   test "Hex dump":
+
+    block:
+      let a = 0x1234567890ABCDEF.stint(128)
+      check: a.dumpHex(bigEndian).toUpperAscii == "00000000000000001234567890ABCDEF"
+
+    block:
+      let a = 0x1234567890ABCDEF.stuint(128)
+      check: a.dumpHex(bigEndian).toUpperAscii == "00000000000000001234567890ABCDEF"
+
     block:
       let a = 0x1234'i32.stint(32)
       check: a.dumpHex(bigEndian).toUpperAscii == "00001234"


### PR DESCRIPTION
stint_test was mistakingly removed during this PR:

- https://github.com/status-im/nim-stint/commit/9027fbea3e28464edd6988a4d5ffd9e38369b797#diff-f54708799999adbdf1391779f2bc0c45L97
- https://github.com/status-im/nim-stint/commit/9027fbea3e28464edd6988a4d5ffd9e38369b797#diff-f54708799999adbdf1391779f2bc0c45R100

This was helpful for testing the core logic.

Unfortunately the `assignLo` macro doesn't provide the full functionality of `assign_leastSignificantWords` that was able to deal with uint64 = 2xuint32