### PR TITLE
[RDY] improve compile time tests coverage

### DIFF
--- a/stint/endians2.nim
+++ b/stint/endians2.nim
@@ -7,7 +7,7 @@
 #
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import private/[bitops2_priv, endians2_priv, datatypes]
+import private/[bitops2_priv, endians2_priv, datatypes, compiletime_helpers]
 
 import stew/endians2
 export endians2
@@ -30,8 +30,11 @@ func fromBytes*[bits: static int](
     T: typedesc[StUint[bits]],
     x: array[bits div 8, byte],
     endian: Endianness = system.cpuEndian): T {.inline, noinit.} =
-  # TODO compile-time version
-  copyMem(addr result, unsafeAddr x[0], bits div 8)
+
+  when nimvm:
+    copyFromArray(result.data, x)
+  else:
+    copyMem(addr result, unsafeAddr x[0], bits div 8)
 
   if endian != system.cpuEndian:
     result = swapBytes(result)

--- a/stint/intops.nim
+++ b/stint/intops.nim
@@ -127,7 +127,16 @@ func `xor`*(x, y: SomeBigInteger): SomeBigInteger {.inline.}=
   result.data = x.data xor y.data
 
 func `shr`*(x: SomeBigInteger, y: SomeInteger): SomeBigInteger {.inline.} =
-  result.data = x.data shr y
+  when x.data is SomeSignedInt:
+    when (NimMajor, NimMinor, NimPatch) >= (0, 20, 0):
+      result.data = x.data shr y
+    elif (NimMajor, NimMinor, NimPatch) < (0, 20, 0) and defined(nimAshr):
+      result.data = ashr(x.data, y)
+    else:
+      {.error: "arithmetic right shift is not defined for this Nim version".}
+  else:
+    result.data = x.data shr y
+
 func `shl`*(x: SomeBigInteger, y: SomeInteger): SomeBigInteger {.inline.} =
   result.data = x.data shl y
 

--- a/stint/intops.nim
+++ b/stint/intops.nim
@@ -94,7 +94,7 @@ func isZero*(x: SomeBigInteger): bool {.inline.} =
   ## false otherwise
   x.data.isZero
 
-func isNegative*(x: SomeBigInteger): bool {.inline.} =
+func isNegative*(x: Stint): bool {.inline.} =
   ## Returns true if input is negative (< 0)
   ## false otherwise
   x.data.isNegative

--- a/stint/io.nim
+++ b/stint/io.nim
@@ -10,7 +10,7 @@
 import
   ./private/datatypes,
   ./private/int_negabs,
-  ./private/[int_bitwise_ops, uint_bitwise_ops],
+  ./private/compiletime_helpers,
   ./intops,
   typetraits, algorithm
 
@@ -285,13 +285,11 @@ proc dumpHex*(x: Stint or StUint, order: static[Endianness] = bigEndian): string
   result = newString(2*size)
 
   when nimvm:
-    type DT = type x.data.leastSignificantWord
     for i in 0 ..< size:
       when order == system.cpuEndian:
-        let pos = (i * 8)
+        let byte = x.data.getByte(i)
       else:
-        let pos = ((size - (i + 1)) * 8)
-      let byte = (x.data shr pos).leastSignificantWord and 0xFF.DT
+        let byte = x.data.getByte(size - 1 - i)
       result[2*i] = hexChars[int byte shr 4 and 0xF]
       result[2*i+1] = hexChars[int byte and 0xF]
   else:

--- a/stint/io.nim
+++ b/stint/io.nim
@@ -183,7 +183,7 @@ func parse*[bits: static[int]](input: string, T: typedesc[Stint[bits]], radix: s
   else:
     result = convert[T](no_overflow)
 
-func fromHex*(T: type StUint, s: string): T {.inline.} =
+func fromHex*(T: typedesc[StUint|Stint], s: string): T {.inline.} =
   ## Convert an hex string to the corresponding unsigned integer
   parse(s, type result, radix = 16)
 

--- a/stint/io.nim
+++ b/stint/io.nim
@@ -264,7 +264,7 @@ func toHex*[bits: static[int]](num: Stint[bits] or StUint[bits]): string {.inlin
   ## Leading zeros are stripped. Use dumpHex instead if you need the in-memory representation
   toString(num, 16)
 
-proc dumpHex*(x: Stint or StUint, order: static[Endianness] = bigEndian): string =
+func dumpHex*(x: Stint or StUint, order: static[Endianness] = bigEndian): string =
   ## Stringify an int to hex.
   ## Note. Leading zeros are not removed. Use toString(n, base = 16)/toHex instead.
   ##

--- a/stint/private/compiletime_helpers.nim
+++ b/stint/private/compiletime_helpers.nim
@@ -1,5 +1,20 @@
 import ./datatypes, ./uint_bitwise_ops
 
+func convertImpl[T: SomeInteger](x: SomeInteger): T {.compileTime.} =
+  cast[T](x)
+
+func convertImpl[T: IntImpl|UintImpl](x: IntImpl|UintImpl): T {.compileTime.} =
+  result.hi = convertImpl[type(result.hi)](x.hi)
+  result.lo = x.lo
+
+template convert*[T](x: UintImpl|IntImpl|SomeInteger): T =
+  when nimvm:
+    # this is a workaround Nim VM inability to cast
+    # something non integer
+    convertImpl[T](x)
+  else:
+    cast[T](x)
+    
 func getByte*(x: SomeInteger, pos: int): byte {.compileTime.} =
   type DT = type x
   byte((x shr (pos * 8)) and 0xFF.DT)

--- a/stint/private/compiletime_helpers.nim
+++ b/stint/private/compiletime_helpers.nim
@@ -1,4 +1,4 @@
-import ./datatypes, ./uint_bitwise_ops
+import ./datatypes, ./uint_bitwise_ops, ./bitops2_priv
 
 func convertImpl[T: SomeInteger](x: SomeInteger): T {.compileTime.} =
   cast[T](x)
@@ -14,7 +14,7 @@ template convert*[T](x: UintImpl|IntImpl|SomeInteger): T =
     convertImpl[T](x)
   else:
     cast[T](x)
-    
+
 func getByte*(x: SomeInteger, pos: int): byte {.compileTime.} =
   type DT = type x
   byte((x shr (pos * 8)) and 0xFF.DT)
@@ -22,3 +22,38 @@ func getByte*(x: SomeInteger, pos: int): byte {.compileTime.} =
 func getByte*(x: UintImpl | IntImpl, pos: int): byte {.compileTime.} =
   type DT = type x.leastSignificantWord
   byte((x shr (pos * 8)).leastSignificantWord and 0xFF.DT)
+
+proc setByte*(x: var SomeInteger, pos: int, b: byte) {.compileTime.} =
+  type DT = type x
+  x = x or (DT(b) shl (pos*8))
+
+type SomeIntImpl = UintImpl | IntImpl
+func setByte*(x: var SomeIntImpl, pos: int, b: byte) {.compileTime.} =
+  proc putFirstByte(x: var SomeInteger, b: byte) =
+    type DT = type x
+    x = x or b.DT
+
+  proc putFirstByte(x: var UintImpl, b: byte) =
+    putFirstByte(x.lo, b)
+
+  var cx: type x
+  cx.putFirstByte(b)
+  x = x or (cx shl (pos*8))
+
+func copyToArray*(ret: var openArray[byte], x: UintImpl) {.compileTime.} =
+  const size = bitsof(x) div 8
+  doAssert ret.len >= size
+  for i in 0 ..< size:
+    ret[i] = x.getByte(i)
+
+func copyFromArray*(x: var UintImpl, data: openArray[byte]) {.compileTime.} =
+  const size = bitsof(x) div 8
+  doAssert data.len >= size
+  for i in 0 ..< size:
+    x.setByte(i, data[i])
+
+func copyFromArray*(x: var SomeInteger, data: openArray[byte]) {.compileTime.} =
+  const size = bitsof(x) div 8
+  doAssert data.len >= size
+  for i in 0 ..< size:
+    x.setByte(i, data[i])

--- a/stint/private/compiletime_helpers.nim
+++ b/stint/private/compiletime_helpers.nim
@@ -1,0 +1,9 @@
+import ./datatypes, ./uint_bitwise_ops
+
+func getByte*(x: SomeInteger, pos: int): byte {.compileTime.} =
+  type DT = type x
+  byte((x shr (pos * 8)) and 0xFF.DT)
+
+func getByte*(x: UintImpl | IntImpl, pos: int): byte {.compileTime.} =
+  type DT = type x.leastSignificantWord
+  byte((x shr (pos * 8)).leastSignificantWord and 0xFF.DT)

--- a/stint/private/datatypes.nim
+++ b/stint/private/datatypes.nim
@@ -179,6 +179,9 @@ template applyHiLo*(a, b: UintImpl | IntImpl, c: untyped): untyped =
   res.hi = c(a.hi, b.hi)
   res.lo = c(a.lo, b.lo)
   res
+  
+template leastSignificantWord*(num: SomeInteger): auto =
+  num
 
 func leastSignificantWord*(num: UintImpl | IntImpl): auto {.inline.} =
   when num.lo is UintImpl:

--- a/stint/private/endians2_priv.nim
+++ b/stint/private/endians2_priv.nim
@@ -1,4 +1,4 @@
-import ./bitops2_priv, ./datatypes
+import ./bitops2_priv, ./datatypes, ./uint_bitwise_ops
 
 import stew/endians2
 export endians2
@@ -9,13 +9,29 @@ func swapBytes*(x: UintImpl): UintImpl {.inline.} =
 
   UintImpl(hi: hi, lo: lo)
 
+func copyMem(x: UintImpl): auto {.compileTime.} =
+  const size = bitsof(x) div 8
+  var ret: array[size, byte]
+
+  type DT = type x.leastSignificantWord
+  for i in 0 ..< size:
+    let pos = i * 8
+    ret[i] = byte((x shr pos).leastSignificantWord and 0xFF.DT)
+  ret
+
 func toBytes*(x: UintImpl, endian: Endianness = system.cpuEndian): auto {.inline.} =
   # TODO can't use bitsof in return type (compiler bug?), hence return auto
-  # TODO compile-time version
   var ret: array[bitsof(x) div 8, byte]
-  if endian == system.cpuEndian:
-    copyMem(addr ret[0], unsafeAddr x, ret.len)
+  when nimvm:
+    if endian == system.cpuEndian:
+      ret = copyMem(x)
+    else:
+      let v = swapBytes(x)
+      ret = copyMem(v)
   else:
-    let v = swapBytes(x)
-    copyMem(addr ret[0], unsafeAddr v, ret.len)
+    if endian == system.cpuEndian:
+      copyMem(addr ret[0], unsafeAddr x, ret.len)
+    else:
+      let v = swapBytes(x)
+      copyMem(addr ret[0], unsafeAddr v, ret.len)
   ret

--- a/stint/private/endians2_priv.nim
+++ b/stint/private/endians2_priv.nim
@@ -1,5 +1,4 @@
-import ./bitops2_priv, ./datatypes, ./uint_bitwise_ops
-
+import ./bitops2_priv, ./datatypes, ./compiletime_helpers
 import stew/endians2
 export endians2
 
@@ -9,25 +8,21 @@ func swapBytes*(x: UintImpl): UintImpl {.inline.} =
 
   UintImpl(hi: hi, lo: lo)
 
-func copyMem(x: UintImpl): auto {.compileTime.} =
+func copyMem(x: UintImpl, ret: var openArray[byte]) {.compileTime.} =
   const size = bitsof(x) div 8
-  var ret: array[size, byte]
-
   type DT = type x.leastSignificantWord
   for i in 0 ..< size:
-    let pos = i * 8
-    ret[i] = byte((x shr pos).leastSignificantWord and 0xFF.DT)
-  ret
+    ret[i] = x.getByte(i)
 
 func toBytes*(x: UintImpl, endian: Endianness = system.cpuEndian): auto {.inline.} =
   # TODO can't use bitsof in return type (compiler bug?), hence return auto
   var ret: array[bitsof(x) div 8, byte]
   when nimvm:
     if endian == system.cpuEndian:
-      ret = copyMem(x)
+      copyMem(x, ret)
     else:
       let v = swapBytes(x)
-      ret = copyMem(v)
+      copyMem(v, ret)
   else:
     if endian == system.cpuEndian:
       copyMem(addr ret[0], unsafeAddr x, ret.len)

--- a/stint/private/endians2_priv.nim
+++ b/stint/private/endians2_priv.nim
@@ -8,21 +8,15 @@ func swapBytes*(x: UintImpl): UintImpl {.inline.} =
 
   UintImpl(hi: hi, lo: lo)
 
-func copyMem*(x: UintImpl, ret: var openArray[byte]) {.compileTime.} =
-  const size = bitsof(x) div 8
-  type DT = type x.leastSignificantWord
-  for i in 0 ..< size:
-    ret[i] = x.getByte(i)
-
 func toBytes*(x: UintImpl, endian: Endianness = system.cpuEndian): auto {.inline.} =
   # TODO can't use bitsof in return type (compiler bug?), hence return auto
   var ret: array[bitsof(x) div 8, byte]
   when nimvm:
     if endian == system.cpuEndian:
-      copyMem(x, ret)
+      copyToArray(ret, x)
     else:
       let v = swapBytes(x)
-      copyMem(v, ret)
+      copyToArray(ret, v)
   else:
     if endian == system.cpuEndian:
       copyMem(addr ret[0], unsafeAddr x, ret.len)

--- a/stint/private/endians2_priv.nim
+++ b/stint/private/endians2_priv.nim
@@ -8,7 +8,7 @@ func swapBytes*(x: UintImpl): UintImpl {.inline.} =
 
   UintImpl(hi: hi, lo: lo)
 
-func copyMem(x: UintImpl, ret: var openArray[byte]) {.compileTime.} =
+func copyMem*(x: UintImpl, ret: var openArray[byte]) {.compileTime.} =
   const size = bitsof(x) div 8
   type DT = type x.leastSignificantWord
   for i in 0 ..< size:

--- a/stint/private/int_bitwise_ops.nim
+++ b/stint/private/int_bitwise_ops.nim
@@ -7,7 +7,7 @@
 #
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import  ./datatypes, ./bitops2_priv, ./uint_bitwise_ops
+import  ./datatypes, ./bitops2_priv, ./uint_bitwise_ops, ./compiletime_helpers
 
 func `not`*(x: IntImpl): IntImpl {.inline.}=
   ## Bitwise complement of unsigned integer x
@@ -24,21 +24,6 @@ func `and`*(x, y: IntImpl): IntImpl {.inline.}=
 func `xor`*(x, y: IntImpl): IntImpl {.inline.}=
   ## `Bitwise xor` of numbers x and y
   applyHiLo(x, y, `xor`)
-
-func convertImpl[T: SomeInteger](x: SomeInteger): T {.compileTime.} =
-  cast[T](x)
-
-func convertImpl[T: IntImpl|UintImpl](x: IntImpl|UintImpl): T {.compileTime.} =
-  result.hi = convertImpl[type(result.hi)](x.hi)
-  result.lo = x.lo
-
-template convert[T](x: UintImpl|IntImpl|SomeInteger): T =
-  when nimvm:
-    # this is a workaround Nim VM inability to cast
-    # something non integer
-    convertImpl[T](x)
-  else:
-    cast[T](x)
 
 func `shl`*(x: IntImpl, y: SomeInteger): IntImpl {.inline.}=
   ## Compute the `shift left` operation of x and y

--- a/stint/private/int_div.nim
+++ b/stint/private/int_div.nim
@@ -7,7 +7,7 @@
 #
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import ./datatypes, ./int_negabs, ./uint_div, ./int_comparison
+import ./datatypes, ./int_negabs, ./uint_div, ./int_comparison, ./compiletime_helpers
 
 # Here are the expected signs for division/modulo by opposite signs and both negative numbers
 #   in EVM
@@ -39,10 +39,17 @@ func divmod*(x, y: SomeSignedInt): tuple[quot, rem: SomeSignedInt] {.inline.}=
 proc divmod*[T, T2](x, y: IntImpl[T, T2]): tuple[quot, rem: IntImpl[T, T2]] =
   ## Divmod operation for multi-precision signed integer
 
-  result = cast[type result](divmod(
-    cast[UintImpl[T2]](x.abs),
-    cast[UintImpl[T2]](y.abs)
-    ))
+  when nimvm:
+    let res = divmod(
+      convert[UintImpl[T2]](x.abs),
+      convert[UintImpl[T2]](y.abs))
+    result.quot = convert[type result.quot](res.quot)
+    result.rem  = convert[type result.rem](res.rem)
+  else:
+    result = cast[type result](divmod(
+      cast[UintImpl[T2]](x.abs),
+      cast[UintImpl[T2]](y.abs)
+      ))
 
   if (x.isNegative xor y.isNegative):
     # If opposite signs

--- a/stint/private/int_mul.nim
+++ b/stint/private/int_mul.nim
@@ -7,11 +7,11 @@
 #
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import ./datatypes, ./uint_mul
+import ./datatypes, ./uint_mul, ./compiletime_helpers
 
 func `*`*[T, T2](x, y: IntImpl[T, T2]): IntImpl[T, T2] {.inline.}=
   ## Multiplication for multi-precision signed integers
   # For 2-complement representation this is the exact same
   # as unsigned multiplication. We don't need to deal with the sign
   # TODO: overflow detection.
-  cast[type result](cast[UIntImpl[T2]](x) * cast[UIntImpl[T2]](y))
+  convert[type result](convert[UIntImpl[T2]](x) * convert[UIntImpl[T2]](y))

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -14,7 +14,8 @@ import  test_uint_bitops2,
         test_uint_addsub,
         test_uint_muldiv,
         test_uint_exp,
-        test_uint_modular_arithmetic
+        test_uint_modular_arithmetic,
+        test_uint_endians2
 
 import  test_int_endianness,
         test_int_comparison,

--- a/tests/test_helpers.nim
+++ b/tests/test_helpers.nim
@@ -1,0 +1,9 @@
+# this is some template to help mimicking unittest at compile time
+# perhaps we can implement a real compile time unittest?
+
+template ctCheck*(cond: untyped) =
+  doAssert(cond)
+
+template ctTest*(name: string, body: untyped) =
+  body
+  echo "[OK] compile time ", name

--- a/tests/test_int_addsub.nim
+++ b/tests/test_int_addsub.nim
@@ -288,7 +288,7 @@ template testAddSub(chk, tst: untyped) =
 static:
   testAddSub(doAssert, ctTest)
 
-suite "Wider signed int coverage":
+suite "Wider signed int addsub coverage":
   testAddSub(check, test)
 
 suite "Testing signed addition implementation":

--- a/tests/test_int_addsub.nim
+++ b/tests/test_int_addsub.nim
@@ -202,13 +202,13 @@ template testAddSub(chk, tst: untyped) =
 
   tst "negation":
     chkNegation(chk, 0, 0, 8)
-    # chkNegation(chk, 128, -128, 8) # TODO: bug #93
+    # chkNegation(chk, 128, -128, 8) # TODO: bug #92
     chkNegation(chk, 127, -127, 8)
 
     chkNegation(chk, 0, 0, 16)
     chkNegation(chk, 128, -128, 16)
     chkNegation(chk, 127, -127, 16)
-    #chkNegation(chk, 32768, -32768, 16) # TODO: bug #93
+    #chkNegation(chk, 32768, -32768, 16) # TODO: bug #92
     chkNegation(chk, 32767, -32767, 16)
 
     chkNegation(chk, 0, 0, 32)
@@ -216,7 +216,7 @@ template testAddSub(chk, tst: untyped) =
     chkNegation(chk, 127, -127, 32)
     chkNegation(chk, 32768, -32768, 32)
     chkNegation(chk, 32767, -32767, 32)
-    #chkNegation(chk, high(int32)+1, low(int32), 32) # TODO: bug #93
+    #chkNegation(chk, high(int32)+1, low(int32), 32) # TODO: bug #92
 
     chkNegation(chk, 0, 0, 64)
     chkNegation(chk, 128, -128, 64)
@@ -225,7 +225,7 @@ template testAddSub(chk, tst: untyped) =
     chkNegation(chk, 32767, -32767, 64)
     chkNegation(chk, 2147483648, -2147483648, 64)
     chkNegation(chk, 2147483647, -2147483647, 64)
-    #chkNegation(chk, 9223372036854775808, -9223372036854775808, 64) # TODO: bug #93
+    #chkNegation(chk, 9223372036854775808, -9223372036854775808, 64) # TODO: bug #92
 
     chkNegation(chk, 0, 0, 128)
     chkNegation(chk, 128, -128, 128)
@@ -234,7 +234,7 @@ template testAddSub(chk, tst: untyped) =
     chkNegation(chk, 32767, -32767, 128)
     chkNegation(chk, 2147483648, -2147483648, 128)
     chkNegation(chk, 2147483647, -2147483647, 128)
-    #chkNegation(chk, 9223372036854775808, -9223372036854775808, 128) # TODO: bug #93
+    #chkNegation(chk, 9223372036854775808, -9223372036854775808, 128) # TODO: bug #92
 
   tst "absolute integer":
     chkAbs(chk, 0, 0, 8)
@@ -245,7 +245,7 @@ template testAddSub(chk, tst: untyped) =
 
     chkAbs(chk, 0, 0, 16)
     chkAbs(chk, -127, 127, 16)
-    chkNegation(chk, -32767, 32767, 16)
+    chkAbs(chk, -32767, 32767, 16)
     chkAbs(chk, -1, 1, 16)
     chkAbs(chk, 1, 1, 16)
     chkAbs(chk, 127, 127, 16)

--- a/tests/test_int_addsub.nim
+++ b/tests/test_int_addsub.nim
@@ -7,7 +7,7 @@
 #
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import ../stint, unittest
+import ../stint, unittest, test_helpers
 
 template chkAddition(chk, a, b, c, bits: untyped) =
   block:
@@ -38,10 +38,6 @@ template chkNegation(chk, a, b, bits: untyped) =
 
 template chkAbs(chk, a, b, bits: untyped) =
   chk stint(a, bits).abs() == stint(b, bits)
-
-template ctTest(name: string, body: untyped) =
-  body
-  echo "[OK] compile time ", name
 
 template testAddSub(chk, tst: untyped) =
   tst "addition":
@@ -286,7 +282,7 @@ template testAddSub(chk, tst: untyped) =
     chkAbs(chk, 9223372036854775807, 9223372036854775807, 128)
 
 static:
-  testAddSub(doAssert, ctTest)
+  testAddSub(ctCheck, ctTest)
 
 suite "Wider signed int addsub coverage":
   testAddSub(check, test)

--- a/tests/test_int_addsub.nim
+++ b/tests/test_int_addsub.nim
@@ -9,6 +9,288 @@
 
 import ../stint, unittest
 
+template chkAddition(chk, a, b, c, bits: untyped) =
+  block:
+    let x = stint(a, bits)
+    let y = stint(b, bits)
+    chk x + y == stint(c, bits)
+
+template chkInplaceAddition(chk, a, b, c, bits: untyped) =
+  block:
+    var x = stint(a, bits)
+    x += stint(b, bits)
+    chk x == stint(c, bits)
+
+template chkSubstraction(chk, a, b, c, bits: untyped) =
+  block:
+    let x = stint(a, bits)
+    let y = stint(b, bits)
+    chk x - y == stint(c, bits)
+
+template chkInplaceSubstraction(chk, a, b, c, bits: untyped) =
+  block:
+    var x = stint(a, bits)
+    x -= stint(b, bits)
+    chk x == stint(c, bits)
+
+template chkNegation(chk, a, b, bits: untyped) =
+  chk -stint(a, bits) == stint(b, bits)
+
+template chkAbs(chk, a, b, bits: untyped) =
+  chk stint(a, bits).abs() == stint(b, bits)
+
+template ctTest(name: string, body: untyped) =
+  body
+  echo "[OK] compile time ", name
+
+template testAddSub(chk, tst: untyped) =
+  tst "addition":
+    chkAddition(chk, 0'i8, 0'i8, 0'i8, 8)
+    chkAddition(chk, high(int8) - 17'i8, 17'i8, high(int8), 8)
+    chkAddition(chk, low(int8) + 17'i8, 17'i8, low(int8) + 34'i8, 8)
+
+    chkAddition(chk, 0'i8, 0'i8, 0'i8, 16)
+    chkAddition(chk, high(int8) - 17'i8, 17'i8, high(int8), 16)
+    chkAddition(chk, low(int8) + 17'i8, 17'i8, low(int8) + 34'i8, 16)
+    chkAddition(chk, high(int16) - 17'i16, 17'i16, high(int16), 16)
+    chkAddition(chk, low(int16) + 17'i16, 17'i16, low(int16) + 34'i16, 16)
+
+    chkAddition(chk, 0'i8, 0'i8, 0'i8, 32)
+    chkAddition(chk, high(int8) - 17'i8, 17'i8, high(int8), 32)
+    chkAddition(chk, low(int8) + 17'i8, 17'i8, low(int8) + 34'i8, 32)
+    chkAddition(chk, high(int16) - 17'i16, 17'i16, high(int16), 32)
+    chkAddition(chk, low(int16) + 17'i16, 17'i16, low(int16) + 34'i16, 32)
+    chkAddition(chk, high(int32) - 17'i32, 17'i32, high(int32), 32)
+    chkAddition(chk, low(int32) + 17'i32, 17'i32, low(int32) + 34'i32, 32)
+
+    chkAddition(chk, 0'i8, 0'i8, 0'i8, 64)
+    chkAddition(chk, high(int8) - 17'i8, 17'i8, high(int8), 64)
+    chkAddition(chk, low(int8) + 17'i8, 17'i8, low(int8) + 34'i8, 64)
+    chkAddition(chk, high(int16) - 17'i16, 17'i16, high(int16), 64)
+    chkAddition(chk, low(int16) + 17'i16, 17'i16, low(int16) + 34'i16, 64)
+    chkAddition(chk, high(int32) - 17'i32, 17'i32, high(int32), 64)
+    chkAddition(chk, low(int32) + 17'i32, 17'i32, low(int32) + 34'i32, 64)
+    chkAddition(chk, high(int64) - 17'i64, 17'i64, high(int64), 64)
+    chkAddition(chk, low(int64) + 17'i64, 17'i64, low(int64) + 34'i64, 64)
+
+    chkAddition(chk, 0'i8, 0'i8, 0'i8, 128)
+    chkAddition(chk, high(int8) - 17'i8, 17'i8, high(int8), 128)
+    chkAddition(chk, low(int8) + 17'i8, 17'i8, low(int8) + 34'i8, 128)
+    chkAddition(chk, high(int16) - 17'i16, 17'i16, high(int16), 128)
+    chkAddition(chk, low(int16) + 17'i16, 17'i16, low(int16) + 34'i16, 128)
+    chkAddition(chk, high(int32) - 17'i32, 17'i32, high(int32), 128)
+    chkAddition(chk, low(int32) + 17'i32, 17'i32, low(int32) + 34'i32, 128)
+    chkAddition(chk, high(int64) - 17'i64, 17'i64, high(int64), 128)
+    chkAddition(chk, low(int64) + 17'i64, 17'i64, low(int64) + 34'i64, 128)
+
+  tst "inplace addition":
+    chkInplaceAddition(chk, 0'i8, 0'i8, 0'i8, 8)
+    chkInplaceAddition(chk, high(int8) - 17'i8, 17'i8, high(int8), 8)
+    chkInplaceAddition(chk, low(int8) + 17'i8, 17'i8, low(int8) + 34'i8, 8)
+
+    chkInplaceAddition(chk, 0'i8, 0'i8, 0'i8, 16)
+    chkInplaceAddition(chk, high(int8) - 17'i8, 17'i8, high(int8), 16)
+    chkInplaceAddition(chk, low(int8) + 17'i8, 17'i8, low(int8) + 34'i8, 16)
+    chkInplaceAddition(chk, high(int16) - 17'i16, 17'i16, high(int16), 16)
+    chkInplaceAddition(chk, low(int16) + 17'i16, 17'i16, low(int16) + 34'i16, 16)
+
+    chkInplaceAddition(chk, 0'i8, 0'i8, 0'i8, 32)
+    chkInplaceAddition(chk, high(int8) - 17'i8, 17'i8, high(int8), 32)
+    chkInplaceAddition(chk, low(int8) + 17'i8, 17'i8, low(int8) + 34'i8, 32)
+    chkInplaceAddition(chk, high(int16) - 17'i16, 17'i16, high(int16), 32)
+    chkInplaceAddition(chk, low(int16) + 17'i16, 17'i16, low(int16) + 34'i16, 32)
+    chkInplaceAddition(chk, high(int32) - 17'i32, 17'i32, high(int32), 32)
+    chkInplaceAddition(chk, low(int32) + 17'i32, 17'i32, low(int32) + 34'i32, 32)
+
+    chkInplaceAddition(chk, 0'i8, 0'i8, 0'i8, 64)
+    chkInplaceAddition(chk, high(int8) - 17'i8, 17'i8, high(int8), 64)
+    chkInplaceAddition(chk, low(int8) + 17'i8, 17'i8, low(int8) + 34'i8, 64)
+    chkInplaceAddition(chk, high(int16) - 17'i16, 17'i16, high(int16), 64)
+    chkInplaceAddition(chk, low(int16) + 17'i16, 17'i16, low(int16) + 34'i16, 64)
+    chkInplaceAddition(chk, high(int32) - 17'i32, 17'i32, high(int32), 64)
+    chkInplaceAddition(chk, low(int32) + 17'i32, 17'i32, low(int32) + 34'i32, 64)
+    chkInplaceAddition(chk, high(int64) - 17'i64, 17'i64, high(int64), 64)
+    chkInplaceAddition(chk, low(int64) + 17'i64, 17'i64, low(int64) + 34'i64, 64)
+
+    chkInplaceAddition(chk, 0'i8, 0'i8, 0'i8, 128)
+    chkInplaceAddition(chk, high(int8) - 17'i8, 17'i8, high(int8), 128)
+    chkInplaceAddition(chk, low(int8) + 17'i8, 17'i8, low(int8) + 34'i8, 128)
+    chkInplaceAddition(chk, high(int16) - 17'i16, 17'i16, high(int16), 128)
+    chkInplaceAddition(chk, low(int16) + 17'i16, 17'i16, low(int16) + 34'i16, 128)
+    chkInplaceAddition(chk, high(int32) - 17'i32, 17'i32, high(int32), 128)
+    chkInplaceAddition(chk, low(int32) + 17'i32, 17'i32, low(int32) + 34'i32, 128)
+    chkInplaceAddition(chk, high(int64) - 17'i64, 17'i64, high(int64), 128)
+    chkInplaceAddition(chk, low(int64) + 17'i64, 17'i64, low(int64) + 34'i64, 128)
+
+  tst "substraction":
+    chkSubstraction(chk, 0'i8, 0'i8, 0'i8, 8)
+    chkSubstraction(chk, high(int8) - 17'i8, 17'i8, high(int8) - 34'i8, 8)
+    chkSubstraction(chk, low(int8) + 17'i8, 17'i8, low(int8), 8)
+
+    chkSubstraction(chk, 0'i8, 0'i8, 0'i8, 16)
+    chkSubstraction(chk, high(int8) - 17'i8, 17'i8, high(int8) - 34'i8, 16)
+    chkSubstraction(chk, low(int8) + 17'i8, 17'i8, low(int8), 16)
+    chkSubstraction(chk, high(int16) - 17'i16, 17'i16, high(int16) - 34'i16, 16)
+    chkSubstraction(chk, low(int16) + 17'i16, 17'i16, low(int16), 16)
+
+    chkSubstraction(chk, 0'i8, 0'i8, 0'i8, 32)
+    chkSubstraction(chk, high(int8) - 17'i8, 17'i8, high(int8) - 34'i8, 32)
+    chkSubstraction(chk, low(int8) + 17'i8, 17'i8, low(int8), 32)
+    chkSubstraction(chk, high(int16) - 17'i16, 17'i16, high(int16) - 34'i16, 32)
+    chkSubstraction(chk, low(int16) + 17'i16, 17'i16, low(int16), 32)
+    chkSubstraction(chk, high(int32) - 17'i32, 17'i32, high(int32) - 34'i32, 32)
+    chkSubstraction(chk, low(int32) + 17'i32, 17'i32, low(int32), 32)
+
+    chkSubstraction(chk, 0'i8, 0'i8, 0'i8, 64)
+    chkSubstraction(chk, high(int8) - 17'i8, 17'i8, high(int8) - 34'i8, 64)
+    chkSubstraction(chk, low(int8) + 17'i8, 17'i8, low(int8), 64)
+    chkSubstraction(chk, high(int16) - 17'i16, 17'i16, high(int16) - 34'i16, 64)
+    chkSubstraction(chk, low(int16) + 17'i16, 17'i16, low(int16), 64)
+    chkSubstraction(chk, high(int32) - 17'i32, 17'i32, high(int32) - 34'i32, 64)
+    chkSubstraction(chk, low(int32) + 17'i32, 17'i32, low(int32), 64)
+    chkSubstraction(chk, high(int64) - 17'i64, 17'i64, high(int64) - 34'i64, 64)
+    chkSubstraction(chk, low(int64) + 17'i64, 17'i64, low(int64), 64)
+
+    chkSubstraction(chk, 0'i8, 0'i8, 0'i8, 128)
+    chkSubstraction(chk, high(int8) - 17'i8, 17'i8, high(int8) - 34'i8, 128)
+    chkSubstraction(chk, -high(int8), -high(int8), 0'i8, 128)
+    chkSubstraction(chk, high(int16) - 17'i16, 17'i16, high(int16) - 34'i16, 128)
+    chkSubstraction(chk, -high(int16), -high(int16), 0'i16, 128)
+    chkSubstraction(chk, high(int32) - 17'i32, 17'i32, high(int32) - 34'i32, 128)
+    chkSubstraction(chk, -high(int32), -high(int32), 0'i32, 128)
+    chkSubstraction(chk, high(int64) - 17'i64, 17'i64, high(int64) - 34'i64, 128)
+    chkSubstraction(chk, -high(int64), -high(int64), 0'i64, 128)
+
+  tst "inplace substraction":
+    chkInplaceSubstraction(chk, 0'i8, 0'i8, 0'i8, 8)
+    chkInplaceSubstraction(chk, high(int8) - 17'i8, 17'i8, high(int8) - 34'i8, 8)
+    chkInplaceSubstraction(chk, low(int8) + 17'i8, 17'i8, low(int8), 8)
+
+    chkInplaceSubstraction(chk, 0'i8, 0'i8, 0'i8, 16)
+    chkInplaceSubstraction(chk, high(int8) - 17'i8, 17'i8, high(int8) - 34'i8, 16)
+    chkInplaceSubstraction(chk, low(int8) + 17'i8, 17'i8, low(int8), 16)
+    chkInplaceSubstraction(chk, high(int16) - 17'i16, 17'i16, high(int16) - 34'i16, 16)
+    chkInplaceSubstraction(chk, low(int16) + 17'i16, 17'i16, low(int16), 16)
+
+    chkInplaceSubstraction(chk, 0'i8, 0'i8, 0'i8, 32)
+    chkInplaceSubstraction(chk, high(int8) - 17'i8, 17'i8, high(int8) - 34'i8, 32)
+    chkInplaceSubstraction(chk, low(int8) + 17'i8, 17'i8, low(int8), 32)
+    chkInplaceSubstraction(chk, high(int16) - 17'i16, 17'i16, high(int16) - 34'i16, 32)
+    chkInplaceSubstraction(chk, low(int16) + 17'i16, 17'i16, low(int16), 32)
+    chkInplaceSubstraction(chk, high(int32) - 17'i32, 17'i32, high(int32) - 34'i32, 32)
+    chkInplaceSubstraction(chk, low(int32) + 17'i32, 17'i32, low(int32), 32)
+
+    chkInplaceSubstraction(chk, 0'i8, 0'i8, 0'i8, 64)
+    chkInplaceSubstraction(chk, high(int8) - 17'i8, 17'i8, high(int8) - 34'i8, 64)
+    chkInplaceSubstraction(chk, low(int8) + 17'i8, 17'i8, low(int8), 64)
+    chkInplaceSubstraction(chk, high(int16) - 17'i16, 17'i16, high(int16) - 34'i16, 64)
+    chkInplaceSubstraction(chk, low(int16) + 17'i16, 17'i16, low(int16), 64)
+    chkInplaceSubstraction(chk, high(int32) - 17'i32, 17'i32, high(int32) - 34'i32, 64)
+    chkInplaceSubstraction(chk, low(int32) + 17'i32, 17'i32, low(int32), 64)
+    chkInplaceSubstraction(chk, high(int64) - 17'i64, 17'i64, high(int64) - 34'i64, 64)
+    chkInplaceSubstraction(chk, low(int64) + 17'i64, 17'i64, low(int64), 64)
+
+    chkInplaceSubstraction(chk, 0'i8, 0'i8, 0'i8, 128)
+    chkInplaceSubstraction(chk, high(int8) - 17'i8, 17'i8, high(int8) - 34'i8, 128)
+    chkInplaceSubstraction(chk, -high(int8), -high(int8), 0'i8, 128)
+    chkInplaceSubstraction(chk, high(int16) - 17'i16, 17'i16, high(int16) - 34'i16, 128)
+    chkInplaceSubstraction(chk, -high(int16), -high(int16), 0'i16, 128)
+    chkInplaceSubstraction(chk, high(int32) - 17'i32, 17'i32, high(int32) - 34'i32, 128)
+    chkInplaceSubstraction(chk, -high(int32), -high(int32), 0'i32, 128)
+    chkInplaceSubstraction(chk, high(int64) - 17'i64, 17'i64, high(int64) - 34'i64, 128)
+    chkInplaceSubstraction(chk, -high(int64), -high(int64), 0'i64, 128)
+
+  tst "negation":
+    chkNegation(chk, 0, 0, 8)
+    # chkNegation(chk, 128, -128, 8) # TODO: bug #93
+    chkNegation(chk, 127, -127, 8)
+
+    chkNegation(chk, 0, 0, 16)
+    chkNegation(chk, 128, -128, 16)
+    chkNegation(chk, 127, -127, 16)
+    #chkNegation(chk, 32768, -32768, 16) # TODO: bug #93
+    chkNegation(chk, 32767, -32767, 16)
+
+    chkNegation(chk, 0, 0, 32)
+    chkNegation(chk, 128, -128, 32)
+    chkNegation(chk, 127, -127, 32)
+    chkNegation(chk, 32768, -32768, 32)
+    chkNegation(chk, 32767, -32767, 32)
+    #chkNegation(chk, high(int32)+1, low(int32), 32) # TODO: bug #93
+
+    chkNegation(chk, 0, 0, 64)
+    chkNegation(chk, 128, -128, 64)
+    chkNegation(chk, 127, -127, 64)
+    chkNegation(chk, 32768, -32768, 64)
+    chkNegation(chk, 32767, -32767, 64)
+    chkNegation(chk, 2147483648, -2147483648, 64)
+    chkNegation(chk, 2147483647, -2147483647, 64)
+    #chkNegation(chk, 9223372036854775808, -9223372036854775808, 64) # TODO: bug #93
+
+    chkNegation(chk, 0, 0, 128)
+    chkNegation(chk, 128, -128, 128)
+    chkNegation(chk, 127, -127, 128)
+    chkNegation(chk, 32768, -32768, 128)
+    chkNegation(chk, 32767, -32767, 128)
+    chkNegation(chk, 2147483648, -2147483648, 128)
+    chkNegation(chk, 2147483647, -2147483647, 128)
+    #chkNegation(chk, 9223372036854775808, -9223372036854775808, 128) # TODO: bug #93
+
+  tst "absolute integer":
+    chkAbs(chk, 0, 0, 8)
+    chkAbs(chk, -127, 127, 8)
+    chkAbs(chk, -1, 1, 8)
+    chkAbs(chk, 1, 1, 8)
+    chkAbs(chk, 127, 127, 8)
+
+    chkAbs(chk, 0, 0, 16)
+    chkAbs(chk, -127, 127, 16)
+    chkNegation(chk, -32767, 32767, 16)
+    chkAbs(chk, -1, 1, 16)
+    chkAbs(chk, 1, 1, 16)
+    chkAbs(chk, 127, 127, 16)
+    chkAbs(chk, 32767, 32767, 16)
+
+    chkAbs(chk, 0, 0, 32)
+    chkAbs(chk, -127, 127, 32)
+    chkAbs(chk, -32767, 32767, 32)
+    chkAbs(chk, -1, 1, 32)
+    chkAbs(chk, 1, 1, 32)
+    chkAbs(chk, 127, 127, 32)
+    chkAbs(chk, 32767, 32767, 32)
+    chkAbs(chk, -2147483647, 2147483647, 32)
+    chkAbs(chk, 2147483647, 2147483647, 32)
+
+    chkAbs(chk, 0, 0, 64)
+    chkAbs(chk, -127, 127, 64)
+    chkAbs(chk, -32767, 32767, 64)
+    chkAbs(chk, -1, 1, 64)
+    chkAbs(chk, 1, 1, 64)
+    chkAbs(chk, 127, 127, 64)
+    chkAbs(chk, 32767, 32767, 64)
+    chkAbs(chk, -2147483647, 2147483647, 64)
+    chkAbs(chk, 2147483647, 2147483647, 64)
+    chkAbs(chk, -9223372036854775807, 9223372036854775807, 64)
+    chkAbs(chk, 9223372036854775807, 9223372036854775807, 64)
+
+    chkAbs(chk, 0, 0, 128)
+    chkAbs(chk, -127, 127, 128)
+    chkAbs(chk, -32767, 32767, 128)
+    chkAbs(chk, -1, 1, 128)
+    chkAbs(chk, 1, 1, 128)
+    chkAbs(chk, 127, 127, 128)
+    chkAbs(chk, 32767, 32767, 128)
+    chkAbs(chk, -2147483647, 2147483647, 128)
+    chkAbs(chk, 2147483647, 2147483647, 128)
+    chkAbs(chk, -9223372036854775807, 9223372036854775807, 128)
+    chkAbs(chk, 9223372036854775807, 9223372036854775807, 128)
+
+static:
+  testAddSub(doAssert, ctTest)
+
+suite "Wider signed int coverage":
+  testAddSub(check, test)
+
 suite "Testing signed addition implementation":
   test "In-place addition gives expected result":
 

--- a/tests/test_int_bitwise.nim
+++ b/tests/test_int_bitwise.nim
@@ -7,7 +7,7 @@
 #
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import ../stint, unittest
+import ../stint, unittest, test_helpers
 
 template chkNot(chk: untyped, a, b: distinct SomeInteger, bits: int) =
   chk stint(a, bits).not() == stint(b, bits)
@@ -29,10 +29,6 @@ template chkShl(chk: untyped, a: string, b: SomeInteger, c: string, bits: int) =
 
 template chkShr(chk: untyped, a: string, b: SomeInteger, c: string, bits: int) =
   chk (fromHex(Stint[bits], a) shr b) == fromHex(Stint[bits], c)
-
-template ctTest(name: string, body: untyped) =
-  body
-  echo "[OK] compile time ", name
 
 template testBitwise(chk, tst: untyped) =
 
@@ -310,7 +306,7 @@ template testBitwise(chk, tst: untyped) =
     chkShr(chk, "F000000000000000000000000000000000000000000000000000000000000000", 233, "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF80000", 256)
 
 static:
-  testBitwise(doAssert, ctTest)
+  testBitwise(ctCheck, ctTest)
 
 suite "Wider signed int bitwise coverage":
   testBitwise(check, test)

--- a/tests/test_int_bitwise.nim
+++ b/tests/test_int_bitwise.nim
@@ -9,6 +9,312 @@
 
 import ../stint, unittest
 
+template chkNot(chk: untyped, a, b: distinct SomeInteger, bits: int) =
+  chk stint(a, bits).not() == stint(b, bits)
+
+template chkNot(chk: untyped, a, b: string, bits: int) =
+  chk fromHex(Stint[bits], a).not() == fromHex(Stint[bits], b)
+
+template chkOr(chk: untyped, a, b, c: string, bits: int) =
+  chk (fromHex(Stint[bits], a) or fromHex(Stint[bits], b)) == fromHex(Stint[bits], c)
+
+template chkAnd(chk: untyped, a, b, c: string, bits: int) =
+  chk (fromHex(Stint[bits], a) and fromHex(Stint[bits], b)) == fromHex(Stint[bits], c)
+
+template chkXor(chk: untyped, a, b, c: string, bits: int) =
+  chk (fromHex(Stint[bits], a) xor fromHex(Stint[bits], b)) == fromHex(Stint[bits], c)
+
+template chkShl(chk: untyped, a: string, b: SomeInteger, c: string, bits: int) =
+  chk (fromHex(Stint[bits], a) shl b) == fromHex(Stint[bits], c)
+
+template chkShr(chk: untyped, a: string, b: SomeInteger, c: string, bits: int) =
+  chk (fromHex(Stint[bits], a) shr b) == fromHex(Stint[bits], c)
+
+template ctTest(name: string, body: untyped) =
+  body
+  echo "[OK] compile time ", name
+
+template testBitwise(chk, tst: untyped) =
+
+  # TODO: see issue #95
+  #chkShl(chk, "0F", 8, "00", 8)
+  #chkShl(chk, "0F", 16, "00", 16)
+  #chkShl(chk, "0F", 32, "00", 32)
+  #chkShl(chk, "0F", 64, "00", 64)
+  #chkShl(chk, "0F", 128, "00", 128)
+  #chkShl(chk, "0F", 256, "00", 256)
+  #
+  #chkShr(chk, "F0", 8, "00", 8)
+  #chkShr(chk, "F000", 16, "00", 16)
+  #chkShr(chk, "F0000000", 32, "00", 32)
+  #chkShr(chk, "F000000000000000", 64, "00", 64)
+  #chkShr(chk, "F0000000000000000000000000000000", 128, "00", 128)
+
+  tst "operator `not`":
+    chkNot(chk, 0'i8, not 0'i8, 8)
+    chkNot(chk, high(int8), not high(int8), 8)
+    chkNot(chk, "0F", "F0", 8)
+    chkNot(chk, "F0", "0F", 8)
+
+    chkNot(chk, 0'i8, not 0'i16, 16)
+    chkNot(chk, 0'i16, not 0'i16, 16)
+    chkNot(chk, high(int8), not int16(high(int8)), 16)
+    chkNot(chk, high(int16), not high(int16), 16)
+    chkNot(chk, "F0", "FF0F", 16)
+    chkNot(chk, "0F", "FFF0", 16)
+    chkNot(chk, "FF00", "00FF", 16)
+    chkNot(chk, "00FF", "FF00", 16)
+    chkNot(chk, "0FF0", "F00F", 16)
+
+    chkNot(chk, 0'i8, not 0'i32, 32)
+    chkNot(chk, 0'i16, not 0'i32, 32)
+    chkNot(chk, 0'i32, not 0'i32, 32)
+    chkNot(chk, high(int8), not int32(high(int8)), 32)
+    chkNot(chk, high(int16), not int32(high(int16)), 32)
+    chkNot(chk, high(int32), not high(int32), 32)
+    chkNot(chk, "F0", "FFFFFF0F", 32)
+    chkNot(chk, "0F", "FFFFFFF0", 32)
+    chkNot(chk, "FF00", "FFFF00FF", 32)
+    chkNot(chk, "00FF", "FFFFFF00", 32)
+    chkNot(chk, "0000FFFF", "FFFF0000", 32)
+    chkNot(chk, "00FFFF00", "FF0000FF", 32)
+    chkNot(chk, "0F0F0F0F", "F0F0F0F0", 32)
+
+    chkNot(chk, 0'i8, not 0'i64, 64)
+    chkNot(chk, 0'i16, not 0'i64, 64)
+    chkNot(chk, 0'i32, not 0'i64, 64)
+    chkNot(chk, 0'i64, not 0'i64, 64)
+    chkNot(chk, high(int8), not int64(high(int8)), 64)
+    chkNot(chk, high(int16), not int64(high(int16)), 64)
+    chkNot(chk, high(int32), not int64(high(int32)), 64)
+    chkNot(chk, high(int64), not high(int64), 64)
+
+    chkNot(chk, "0", "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", 128)
+    chkNot(chk, "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "0", 128)
+    chkNot(chk, "F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0", "0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F", 128)
+    chkNot(chk, "FFFFFFFFFFFF00000000000000000000", "000000000000FFFFFFFFFFFFFFFFFFFF", 128)
+
+  tst "operator `or`":
+    chkOr(chk, "00", "FF", "FF", 8)
+    chkOr(chk, "FF", "00", "FF", 8)
+    chkOr(chk, "F0", "0F", "FF", 8)
+    chkOr(chk, "00", "00", "00", 8)
+
+    chkOr(chk, "00", "FF", "00FF", 16)
+    chkOr(chk, "FF", "00", "00FF", 16)
+    chkOr(chk, "F0", "0F", "00FF", 16)
+    chkOr(chk, "00", "00", "0000", 16)
+    chkOr(chk, "FF00", "0F00", "FF00", 16)
+
+    chkOr(chk, "00", "FF", "000000FF", 32)
+    chkOr(chk, "FF", "00", "000000FF", 32)
+    chkOr(chk, "F0", "0F", "000000FF", 32)
+    chkOr(chk, "00", "00", "00000000", 32)
+    chkOr(chk, "FF00", "0F00", "0000FF00", 32)
+    chkOr(chk, "00FF00FF", "000F000F", "00FF00FF", 32)
+
+    chkOr(chk, "00", "FF", "00000000000000FF", 64)
+    chkOr(chk, "FF", "00", "00000000000000FF", 64)
+    chkOr(chk, "F0", "0F", "00000000000000FF", 64)
+    chkOr(chk, "00", "00", "0000000000000000", 64)
+    chkOr(chk, "FF00", "0F00", "000000000000FF00", 64)
+    chkOr(chk, "00FF00FF", "000F000F", "0000000000FF00FF", 64)
+
+    chkOr(chk, "00", "FF", "000000000000000000000000000000FF", 128)
+    chkOr(chk, "FF", "00", "000000000000000000000000000000FF", 128)
+    chkOr(chk, "F0", "0F", "000000000000000000000000000000FF", 128)
+    chkOr(chk, "00", "00", "00000000000000000000000000000000", 128)
+    chkOr(chk, "FF00", "0F00", "0000000000000000000000000000FF00", 128)
+    chkOr(chk, "00FF00FF", "000F000F", "00000000000000000000000000FF00FF", 128)
+    chkOr(chk, "00000000000000000000000000FF00FF", "FF0F0000000000000000000000FF00FF", "FF0F0000000000000000000000FF00FF", 128)
+
+  tst "operator `and`":
+    chkAnd(chk, "00", "FF", "00", 8)
+    chkAnd(chk, "FF", "00", "00", 8)
+    chkAnd(chk, "F0", "0F", "00", 8)
+    chkAnd(chk, "00", "00", "00", 8)
+    chkAnd(chk, "0F", "0F", "0F", 8)
+    chkAnd(chk, "FF", "FF", "FF", 8)
+
+    chkAnd(chk, "00", "FF", "0000", 16)
+    chkAnd(chk, "FF", "00", "0000", 16)
+    chkAnd(chk, "F0", "0F", "0000", 16)
+    chkAnd(chk, "00", "00", "0000", 16)
+    chkAnd(chk, "FF00", "0F00", "0F00", 16)
+
+    chkAnd(chk, "00", "FF", "00000000", 32)
+    chkAnd(chk, "FF", "00", "00000000", 32)
+    chkAnd(chk, "F0", "0F", "00000000", 32)
+    chkAnd(chk, "00", "00", "00000000", 32)
+    chkAnd(chk, "FF00", "0F00", "00000F00", 32)
+    chkAnd(chk, "00FF00FF", "000F000F", "000F000F", 32)
+
+    chkAnd(chk, "00", "FF", "0000000000000000", 64)
+    chkAnd(chk, "FF", "00", "0000000000000000", 64)
+    chkAnd(chk, "F0", "0F", "0000000000000000", 64)
+    chkAnd(chk, "00", "00", "0000000000000000", 64)
+    chkAnd(chk, "FF00", "0F00", "0000000000000F00", 64)
+    chkAnd(chk, "00FF00FF", "000F000F", "00000000000F000F", 64)
+
+    chkAnd(chk, "00", "FF", "00000000000000000000000000000000", 128)
+    chkAnd(chk, "FF", "00", "00000000000000000000000000000000", 128)
+    chkAnd(chk, "F0", "0F", "00000000000000000000000000000000", 128)
+    chkAnd(chk, "00", "00", "00000000000000000000000000000000", 128)
+    chkAnd(chk, "FF00", "0F00", "00000000000000000000000000000F00", 128)
+    chkAnd(chk, "00FF00FF", "000F000F", "000000000000000000000000000F000F", 128)
+    chkAnd(chk, "F0000000000000000000000000FF00FF", "FF0F0000000000000000000000FF00FF", "F0000000000000000000000000FF00FF", 128)
+
+  tst "operator `xor`":
+    chkXor(chk, "00", "FF", "FF", 8)
+    chkXor(chk, "FF", "00", "FF", 8)
+    chkXor(chk, "F0", "0F", "FF", 8)
+    chkXor(chk, "00", "00", "00", 8)
+    chkXor(chk, "0F", "0F", "00", 8)
+    chkXor(chk, "FF", "FF", "00", 8)
+
+    chkXor(chk, "00", "FF", "00FF", 16)
+    chkXor(chk, "FF", "00", "00FF", 16)
+    chkXor(chk, "F0", "0F", "00FF", 16)
+    chkXor(chk, "00", "00", "0000", 16)
+    chkXor(chk, "FF00", "0F00", "F000", 16)
+
+    chkXor(chk, "00", "FF", "000000FF", 32)
+    chkXor(chk, "FF", "00", "000000FF", 32)
+    chkXor(chk, "F0", "0F", "000000FF", 32)
+    chkXor(chk, "00", "00", "00000000", 32)
+    chkXor(chk, "FF00", "0F00", "0000F000", 32)
+    chkXor(chk, "00FF00FF", "000F000F", "00F000F0", 32)
+
+    chkXor(chk, "00", "FF", "00000000000000FF", 64)
+    chkXor(chk, "FF", "00", "00000000000000FF", 64)
+    chkXor(chk, "F0", "0F", "00000000000000FF", 64)
+    chkXor(chk, "00", "00", "0000000000000000", 64)
+    chkXor(chk, "FF00", "0F00", "000000000000F000", 64)
+    chkXor(chk, "00FF00FF", "000F000F", "0000000000F000F0", 64)
+
+    chkXor(chk, "00", "FF", "000000000000000000000000000000FF", 128)
+    chkXor(chk, "FF", "00", "000000000000000000000000000000FF", 128)
+    chkXor(chk, "F0", "0F", "000000000000000000000000000000FF", 128)
+    chkXor(chk, "00", "00", "00000000000000000000000000000000", 128)
+    chkXor(chk, "FF00", "0F00", "0000000000000000000000000000F000", 128)
+    chkXor(chk, "00FF00FF", "000F000F", "00000000000000000000000000F000F0", 128)
+    chkXor(chk, "F0000000000000000000000000FF00FF", "FF0F0000000000000000000000FF00FF", "0F0F0000000000000000000000000000", 128)
+
+  tst "operator `shl`":
+    chkShl(chk, "0F", 4, "F0", 8)
+    chkShl(chk, "F0", 4, "00", 8)
+    chkShl(chk, "F0", 3, "80", 8)
+    chkShl(chk, "0F", 7, "80", 8)
+
+    chkShl(chk, "0F", 4, "F0", 16)
+    chkShl(chk, "F0", 4, "F00", 16)
+    chkShl(chk, "F0", 3, "780", 16)
+    chkShl(chk, "F000", 3, "8000", 16)
+    chkShl(chk, "0F", 15, "8000", 16)
+
+    chkShl(chk, "0F", 4, "F0", 32)
+    chkShl(chk, "F0", 4, "F00", 32)
+    chkShl(chk, "F0", 3, "780", 32)
+    chkShl(chk, "F000", 3, "78000", 32)
+    chkShl(chk, "F0000000", 3, "80000000", 32)
+    chkShl(chk, "0F", 31, "80000000", 32)
+
+    chkShl(chk, "0F", 4, "F0", 64)
+    chkShl(chk, "F0", 4, "F00", 64)
+    chkShl(chk, "F0", 3, "780", 64)
+    chkShl(chk, "F000", 3, "78000", 64)
+    chkShl(chk, "F0000000", 3, "780000000", 64)
+    chkShl(chk, "F000000000000000", 3, "8000000000000000", 64)
+    chkShl(chk, "0F", 63, "8000000000000000", 64)
+
+    chkShl(chk, "0F", 5, "1E0", 64)
+    chkShl(chk, "0F", 9, "1E00", 64)
+    chkShl(chk, "0F", 17, "1E0000", 64)
+    chkShl(chk, "0F", 33, "1E00000000", 64)
+
+    chkShl(chk, "0F", 4, "F0", 128)
+    chkShl(chk, "F0", 4, "F00", 128)
+    chkShl(chk, "F0", 3, "780", 128)
+    chkShl(chk, "F000", 3, "78000", 128)
+    chkShl(chk, "F0000000", 3, "780000000", 128)
+    chkShl(chk, "F000000000000000", 3, "78000000000000000", 128)
+    chkShl(chk, "F0000000000000000000000000000000", 3, "80000000000000000000000000000000", 128)
+
+    chkShl(chk, "0F", 33, "1E00000000", 128)
+    chkShl(chk, "0F", 65, "1E0000000000000000", 128)
+    chkShl(chk, "0F", 97, "1E000000000000000000000000", 128)
+    chkShl(chk, "0F", 127, "80000000000000000000000000000000", 128)
+
+    chkShl(chk, "0F", 4, "F0", 256)
+    chkShl(chk, "F0", 4, "F00", 256)
+    chkShl(chk, "F0", 3, "780", 256)
+    chkShl(chk, "F000", 3, "78000", 256)
+    chkShl(chk, "F0000000", 3, "780000000", 256)
+    chkShl(chk, "F000000000000000", 3, "78000000000000000", 256)
+    chkShl(chk, "F0000000000000000000000000000000", 3, "780000000000000000000000000000000", 256)
+
+    chkShl(chk, "0F", 33, "1E00000000", 256)
+    chkShl(chk, "0F", 65, "1E0000000000000000", 256)
+    chkShl(chk, "0F", 97, "1E000000000000000000000000", 256)
+    chkShl(chk, "0F", 128, "0F00000000000000000000000000000000", 256)
+    chkShl(chk, "0F", 129, "1E00000000000000000000000000000000", 256)
+    chkShl(chk, "0F", 255, "8000000000000000000000000000000000000000000000000000000000000000", 256)
+
+  tst "operator `shr`":
+    chkShr(chk, "0F", 4, "00", 8)
+    chkShr(chk, "F0", 4, "FF", 8)
+    chkShr(chk, "F0", 3, "FE", 8)
+    chkShr(chk, "F0", 7, "FF", 8)
+
+    chkShr(chk, "0F", 4, "00", 16)
+    chkShr(chk, "F0", 4, "0F", 16)
+    chkShr(chk, "F000", 3, "FE00", 16)
+    chkShr(chk, "F000", 15, "FFFF", 16)
+
+    chkShr(chk, "0F", 4, "00", 32)
+    chkShr(chk, "F0", 4, "0F", 32)
+    chkShr(chk, "F0", 3, "1E", 32)
+    chkShr(chk, "F0000000", 3, "FE000000", 32)
+    chkShr(chk, "F0000000", 31, "FFFFFFFF", 32)
+
+    chkShr(chk, "0F", 4, "00", 64)
+    chkShr(chk, "F0", 4, "0F", 64)
+    chkShr(chk, "F0", 3, "1E", 64)
+    chkShr(chk, "F000", 3, "1E00", 64)
+    chkShr(chk, "F0000000", 3, "1E000000", 64)
+    chkShr(chk, "F000000000000000", 63, "FFFFFFFFFFFFFFFF", 64)
+
+    chkShr(chk, "0F", 4, "00", 128)
+    chkShr(chk, "F0", 4, "0F", 128)
+    chkShr(chk, "F0", 3, "1E", 128)
+    chkShr(chk, "F000", 3, "1E00", 128)
+    chkShr(chk, "F0000000", 3, "1E000000", 128)
+    chkShr(chk, "F000000000000000", 3, "1E00000000000000", 128)
+    chkShr(chk, "F0000000000000000000000000000000", 127, "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", 128)
+
+    chkShr(chk, "F0000000000000000000000000000000", 33, "FFFFFFFFF80000000000000000000000", 128)
+    chkShr(chk, "F0000000000000000000000000000000", 65, "FFFFFFFFFFFFFFFFF800000000000000", 128)
+    chkShr(chk, "F0000000000000000000000000000000", 97, "FFFFFFFFFFFFFFFFFFFFFFFFF8000000", 128)
+
+    chkShr(chk, "0F", 4, "00", 256)
+    chkShr(chk, "F0", 4, "0F", 256)
+    chkShr(chk, "F0", 3, "1E", 256)
+    chkShr(chk, "F000", 3, "1E00", 256)
+    chkShr(chk, "F0000000", 3, "1E000000", 256)
+    chkShr(chk, "F000000000000000", 3, "1E00000000000000", 256)
+    chkShr(chk, "F000000000000000000000000000000000000000000000000000000000000000", 255, "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", 256)
+
+    chkShr(chk, "F000000000000000000000000000000000000000000000000000000000000000", 33, "FFFFFFFFF8000000000000000000000000000000000000000000000000000000", 256)
+    chkShr(chk, "F000000000000000000000000000000000000000000000000000000000000000", 65, "FFFFFFFFFFFFFFFFF80000000000000000000000000000000000000000000000", 256)
+    chkShr(chk, "F000000000000000000000000000000000000000000000000000000000000000", 129, "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF8000000000000000000000000000000", 256)
+    chkShr(chk, "F000000000000000000000000000000000000000000000000000000000000000", 233, "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF80000", 256)
+
+static:
+  testBitwise(doAssert, ctTest)
+
+suite "Wider signed int bitwise coverage":
+  testBitwise(check, test)
+
 when defined(cpp):
   import quicktest, ttmath_compat
 

--- a/tests/test_int_boundchecks.nim
+++ b/tests/test_int_boundchecks.nim
@@ -1,0 +1,5 @@
+import ../stint, unittest
+
+suite "int boundchecks":
+  test "to be implemented":
+    discard

--- a/tests/test_int_comparison.nim
+++ b/tests/test_int_comparison.nim
@@ -9,6 +9,379 @@
 
 import ../stint, unittest
 
+template chkLT(chk: untyped, a, b: string, bits: int) =
+  chk fromHex(Stint[bits], a) < fromHex(Stint[bits], b)
+
+template chknotLT(chk: untyped, a, b: string, bits: int) =
+  chk not(fromHex(Stint[bits], b) < fromHex(Stint[bits], a))
+
+template chkLTE(chk: untyped, a, b: string, bits: int) =
+  chk fromHex(Stint[bits], a) <= fromHex(Stint[bits], b)
+
+template chknotLTE(chk: untyped, a, b: string, bits: int) =
+  chk not(fromHex(Stint[bits], b) <= fromHex(Stint[bits], a))
+
+template chkEQ(chk: untyped, a, b: string, bits: int) =
+  chk fromHex(Stint[bits], a) == fromHex(Stint[bits], b)
+
+template chknotEQ(chk: untyped, a, b: string, bits: int) =
+  chk not(fromHex(Stint[bits], a) == fromHex(Stint[bits], b))
+
+template chkisZero(chk: untyped, a: string, bits: int) =
+  chk fromHex(Stint[bits], a).isZero()
+
+template chknotisZero(chk: untyped, a: string, bits: int) =
+  chk not fromHex(Stint[bits], a).isZero()
+
+template chkisNegative(chk: untyped, a: string, bits: int) =
+  chk fromHex(Stint[bits], a).isNegative()
+
+template chknotisNegative(chk: untyped, a: string, bits: int) =
+  chk not fromHex(Stint[bits], a).isNegative()
+
+template chkisOdd(chk: untyped, a: string, bits: int) =
+  chk fromHex(Stint[bits], a).isOdd()
+
+template chknotisOdd(chk: untyped, a: string, bits: int) =
+  chk (not fromHex(Stint[bits], a).isOdd())
+
+template chkisEven(chk: untyped, a: string, bits: int) =
+  chk fromHex(Stint[bits], a).isEven()
+
+template chknotisEven(chk: untyped, a: string, bits: int) =
+  chk not fromHex(Stint[bits], a).isEven()
+
+template ctTest(name: string, body: untyped) =
+  body
+  echo "[OK] compile time ", name
+
+template testComparison(chk, tst: untyped) =
+  tst "operator `LT`":
+    chkLT(chk, "0", "F", 8)
+    chkLT(chk, "F", "7F", 8)
+    chkLT(chk, "FF", "7F", 8)
+
+    chkLT(chk, "0", "F", 16)
+    chkLT(chk, "F", "FF", 16)
+    chkLT(chk, "FF", "FFF", 16)
+    chkLT(chk, "FFFF", "FFF", 16)
+
+    chkLT(chk, "0", "F", 32)
+    chkLT(chk, "F", "FF", 32)
+    chkLT(chk, "FF", "FFF", 32)
+    chkLT(chk, "FFFF", "FFFFF", 32)
+    chkLT(chk, "FFFFFFFF", "FFFFF", 32)
+
+    chkLT(chk, "0", "F", 64)
+    chkLT(chk, "F", "FF", 64)
+    chkLT(chk, "FF", "FFF", 64)
+    chkLT(chk, "FFFF", "FFFFF", 64)
+    chkLT(chk, "FFFFF", "FFFFFFFF", 64)
+    chkLT(chk, "FFFFFFFFFFFFFFFF", "FFFFFFFF", 64)
+
+    chkLT(chk, "0", "F", 128)
+    chkLT(chk, "F", "FF", 128)
+    chkLT(chk, "FF", "FFF", 128)
+    chkLT(chk, "FFFF", "FFFFF", 128)
+    chkLT(chk, "FFFFF", "FFFFFFFF", 128)
+    chkLT(chk, "FFFFFFFFFFF", "FFFFFFFFFFFFFFFFFFFFFFFF", 128)
+    chkLT(chk, "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "FFFFFFFFFFFFFFFFFFFFFFFF", 128)
+
+  tst "operator not `LT`":
+    chknotLT(chk, "0", "F", 8)
+    chknotLT(chk, "F", "7F", 8)
+    chknotLT(chk, "FF", "7F", 8)
+
+    chknotLT(chk, "0", "F", 16)
+    chknotLT(chk, "F", "FF", 16)
+    chknotLT(chk, "FF", "FFF", 16)
+    chknotLT(chk, "FFFF", "FFF", 16)
+
+    chknotLT(chk, "0", "F", 32)
+    chknotLT(chk, "F", "FF", 32)
+    chknotLT(chk, "FF", "FFF", 32)
+    chknotLT(chk, "FFFF", "FFFFF", 32)
+    chknotLT(chk, "FFFFFFFF", "FFFFF", 32)
+
+    chknotLT(chk, "0", "F", 64)
+    chknotLT(chk, "F", "FF", 64)
+    chknotLT(chk, "FF", "FFF", 64)
+    chknotLT(chk, "FFFF", "FFFFF", 64)
+    chknotLT(chk, "FFFFF", "FFFFFFFF", 64)
+    chknotLT(chk, "FFFFFFFFFFFFFFFF", "FFFFFFFF", 64)
+
+    chknotLT(chk, "0", "F", 128)
+    chknotLT(chk, "F", "FF", 128)
+    chknotLT(chk, "FF", "FFF", 128)
+    chknotLT(chk, "FFFF", "FFFFF", 128)
+    chknotLT(chk, "FFFFF", "FFFFFFFF", 128)
+    chknotLT(chk, "FFFFFFFFFFF", "FFFFFFFFFFFFFFFFFFFFFFFF", 128)
+    chknotLT(chk, "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "FFFFFFFFFFFFFFFFFFFFFFFF", 128)
+
+  tst "operator `LTE`":
+    chkLTE(chk, "0", "F", 8)
+    chkLTE(chk, "F", "7F", 8)
+    chkLTE(chk, "F", "F", 8)
+    chkLTE(chk, "FF", "7F", 8)
+
+    chkLTE(chk, "0", "F", 16)
+    chkLTE(chk, "F", "FF", 16)
+    chkLTE(chk, "FF", "FFF", 16)
+    chkLTE(chk, "FFF", "FFF", 16)
+    chkLTE(chk, "FFFF", "FFF", 16)
+
+    chkLTE(chk, "0", "F", 32)
+    chkLTE(chk, "F", "FF", 32)
+    chkLTE(chk, "FF", "FFF", 32)
+    chkLTE(chk, "FFFF", "FFFFF", 32)
+    chkLTE(chk, "FFFFF", "FFFFF", 32)
+    chkLTE(chk, "FFFFFFFF", "FFFFF", 32)
+
+    chkLTE(chk, "0", "F", 64)
+    chkLTE(chk, "F", "FF", 64)
+    chkLTE(chk, "FF", "FFF", 64)
+    chkLTE(chk, "FFFF", "FFFFF", 64)
+    chkLTE(chk, "FFFFF", "FFFFFFFF", 64)
+    chkLTE(chk, "FFFFFFFF", "FFFFFFFF", 64)
+    chkLTE(chk, "FFFFFFFFFFFFFFFF", "FFFFFFFF", 64)
+
+    chkLTE(chk, "0", "F", 128)
+    chkLTE(chk, "F", "FF", 128)
+    chkLTE(chk, "FF", "FFF", 128)
+    chkLTE(chk, "FFFF", "FFFFF", 128)
+    chkLTE(chk, "FFFFF", "FFFFFFFF", 128)
+    chkLTE(chk, "FFFFFFFFFFF", "FFFFFFFFFFFFFFFFFFFFFFFF", 128)
+    chkLTE(chk, "FFFFFFFFFFFFFFFFFFFFFFFF", "FFFFFFFFFFFFFFFFFFFFFFFF", 128)
+    chkLTE(chk, "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "FFFFFFFFFFFFFFFFFFFFFFFF", 128)
+
+  tst "operator not `LTE`":
+    chknotLTE(chk, "0", "F", 8)
+    chknotLTE(chk, "F", "7F", 8)
+    chknotLTE(chk, "FF", "7F", 8)
+
+    chknotLTE(chk, "0", "F", 16)
+    chknotLTE(chk, "F", "FF", 16)
+    chknotLTE(chk, "FF", "FFF", 16)
+    chknotLTE(chk, "FFFF", "FFF", 16)
+
+    chknotLTE(chk, "0", "F", 32)
+    chknotLTE(chk, "F", "FF", 32)
+    chknotLTE(chk, "FF", "FFF", 32)
+    chknotLTE(chk, "FFFF", "FFFFF", 32)
+    chknotLTE(chk, "FFFFFFFF", "FFFFF", 32)
+
+    chknotLTE(chk, "0", "F", 64)
+    chknotLTE(chk, "F", "FF", 64)
+    chknotLTE(chk, "FF", "FFF", 64)
+    chknotLTE(chk, "FFFF", "FFFFF", 64)
+    chknotLTE(chk, "FFFFF", "FFFFFFFF", 64)
+    chknotLTE(chk, "FFFFFFFFFFFFFFFF", "FFFFFFFF", 64)
+
+    chknotLTE(chk, "0", "F", 128)
+    chknotLTE(chk, "F", "FF", 128)
+    chknotLTE(chk, "FF", "FFF", 128)
+    chknotLTE(chk, "FFFF", "FFFFF", 128)
+    chknotLTE(chk, "FFFFF", "FFFFFFFF", 128)
+    chknotLTE(chk, "FFFFFFFFFFF", "FFFFFFFFFFFFFFFFFFFFFFFF", 128)
+    chknotLTE(chk, "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "FFFFFFFFFFFFFFFFFFFFFFFF", 128)
+
+  tst "operator `EQ`":
+    chkEQ(chk, "0", "0", 8)
+    chkEQ(chk, "FF", "FF", 8)
+    chkEQ(chk, "F", "F", 8)
+
+    chkEQ(chk, "0", "0", 16)
+    chkEQ(chk, "F", "F", 16)
+    chkEQ(chk, "FF", "FF", 16)
+    chkEQ(chk, "FFF", "FFF", 16)
+    chkEQ(chk, "FFFF", "FFFF", 16)
+
+    chkEQ(chk, "0", "0", 32)
+    chkEQ(chk, "F", "F", 32)
+    chkEQ(chk, "FF", "FF", 32)
+    chkEQ(chk, "FFFF", "FFFF", 32)
+    chkEQ(chk, "FFFFF", "FFFFF", 32)
+
+    chkEQ(chk, "0", "0", 64)
+    chkEQ(chk, "F", "F", 64)
+    chkEQ(chk, "FF", "FF", 64)
+    chkEQ(chk, "FFFF", "FFFF", 64)
+    chkEQ(chk, "FFFFF", "FFFFF", 64)
+    chkEQ(chk, "FFFFFFFF", "FFFFFFFF", 64)
+
+    chkEQ(chk, "0", "0", 128)
+    chkEQ(chk, "F", "F", 128)
+    chkEQ(chk, "FF", "FF", 128)
+    chkEQ(chk, "FFFF", "FFFF", 128)
+    chkEQ(chk, "FFFFF", "FFFFF", 128)
+    chkEQ(chk, "FFFFFFFFFFFFFFFFFFFFFFFF", "FFFFFFFFFFFFFFFFFFFFFFFF", 128)
+
+  tst "operator not `EQ`":
+    chknotEQ(chk, "0", "F", 8)
+    chknotEQ(chk, "F", "FF", 8)
+
+    chknotEQ(chk, "0", "F", 16)
+    chknotEQ(chk, "F", "FF", 16)
+    chknotEQ(chk, "FF", "FFA", 16)
+
+    chknotEQ(chk, "0", "F", 32)
+    chknotEQ(chk, "F", "FF", 32)
+    chknotEQ(chk, "FF", "FFF", 32)
+    chknotEQ(chk, "FFFF", "FAFFF", 32)
+
+    chknotEQ(chk, "0", "F", 64)
+    chknotEQ(chk, "F", "FF", 64)
+    chknotEQ(chk, "FF", "FFF", 64)
+    chknotEQ(chk, "FFFF", "FFFFF", 64)
+    chknotEQ(chk, "FFFFF", "FAFFFFFFF", 64)
+
+    chknotEQ(chk, "0", "F", 128)
+    chknotEQ(chk, "F", "FF", 128)
+    chknotEQ(chk, "FF", "FFF", 128)
+    chknotEQ(chk, "FFFF", "FFFFF", 128)
+    chknotEQ(chk, "FFFFF", "FFAFFFFF", 128)
+    chknotEQ(chk, "FFFFFFFFFFF", "AFFFFFFFFFFFFFFFFFFFFFFF", 128)
+
+  tst "operator `isZero`":
+    chkIsZero(chk, "0", 8)
+    chkIsZero(chk, "0", 16)
+    chkIsZero(chk, "0", 32)
+    chkIsZero(chk, "0", 64)
+    chkIsZero(chk, "0", 128)
+    chkIsZero(chk, "0", 256)
+
+  tst "operator not `isZero`":
+    chknotIsZero(chk, "1", 8)
+    chknotIsZero(chk, "2", 16)
+    chknotIsZero(chk, "3", 32)
+    chknotIsZero(chk, "4", 64)
+    chknotIsZero(chk, "5", 128)
+    chknotIsZero(chk, "6", 256)
+
+    chknotIsZero(chk, "FF", 8)
+    chknotIsZero(chk, "FFFF", 16)
+    chknotIsZero(chk, "FFFFFFFF", 32)
+    chknotIsZero(chk, "FFFFFFFFFFFFFFFF", 64)
+    chknotIsZero(chk, "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", 128)
+    chknotIsZero(chk, "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", 256)
+
+  tst "operator `isNegative`":
+    chkisNegative(chk, "F0", 8)
+    chkisNegative(chk, "F000", 16)
+    chkisNegative(chk, "F0000000", 32)
+    chkisNegative(chk, "F000000000000000", 64)
+    chkisNegative(chk, "F0000000000000000000000000000000", 128)
+    chkisNegative(chk, "F000000000000000000000000000000000000000000000000000000000000000", 256)
+
+    chkisNegative(chk, "A1", 8)
+    chkisNegative(chk, "A200", 16)
+    chkisNegative(chk, "A3000000", 32)
+    chkisNegative(chk, "A400000000000000", 64)
+    chkisNegative(chk, "A5000000000000000000000000000000", 128)
+    chkisNegative(chk, "A600000000000000000000000000000000000000000000000000000000000000", 256)
+
+  tst "operator not `isNegative`":
+    chknotIsNegative(chk, "0", 8)
+    chknotIsNegative(chk, "0", 16)
+    chknotIsNegative(chk, "0", 32)
+    chknotIsNegative(chk, "0", 64)
+    chknotIsNegative(chk, "0", 128)
+    chknotIsNegative(chk, "0", 256)
+
+    chknotIsNegative(chk, "1", 8)
+    chknotIsNegative(chk, "2", 16)
+    chknotIsNegative(chk, "3", 32)
+    chknotIsNegative(chk, "4", 64)
+    chknotIsNegative(chk, "5", 128)
+    chknotIsNegative(chk, "6", 256)
+
+    chknotIsNegative(chk, "71", 8)
+    chknotIsNegative(chk, "7200", 16)
+    chknotIsNegative(chk, "73000000", 32)
+    chknotIsNegative(chk, "7400000000000000", 64)
+    chknotIsNegative(chk, "75000000000000000000000000000000", 128)
+    chknotIsNegative(chk, "7600000000000000000000000000000000000000000000000000000000000000", 256)
+
+  tst "operator `isOdd`":
+    chkIsOdd(chk, "1", 8)
+    chkIsOdd(chk, "1", 16)
+    chkIsOdd(chk, "1", 32)
+    chkIsOdd(chk, "1", 64)
+    chkIsOdd(chk, "1", 128)
+    chkIsOdd(chk, "1", 256)
+
+    chkIsOdd(chk, "FF", 8)
+    chkIsOdd(chk, "FFF", 16)
+    chkIsOdd(chk, "FFFFF", 32)
+    chkIsOdd(chk, "FFFFFF", 64)
+    chkIsOdd(chk, "FFFFFFFFFFFFFFF", 128)
+    chkIsOdd(chk, "FFFFFFFFFFFFFFFFFF", 256)
+
+  tst "operator not `isOdd`":
+    chkNotIsOdd(chk, "0", 8)
+    chkNotIsOdd(chk, "0", 16)
+    chkNotIsOdd(chk, "0", 32)
+    chkNotIsOdd(chk, "0", 64)
+    chkNotIsOdd(chk, "0", 128)
+    chkNotIsOdd(chk, "0", 256)
+
+    chkNotIsOdd(chk, "4", 8)
+    chkNotIsOdd(chk, "4", 16)
+    chkNotIsOdd(chk, "4", 32)
+    chkNotIsOdd(chk, "4", 64)
+    chkNotIsOdd(chk, "4", 128)
+    chkNotIsOdd(chk, "4", 256)
+
+    chkNotIsOdd(chk, "A", 8)
+    chkNotIsOdd(chk, "AAA", 16)
+    chkNotIsOdd(chk, "AAAA", 32)
+    chkNotIsOdd(chk, "FFFFFA", 64)
+    chkNotIsOdd(chk, "FFFFFFFFFFFFFFA", 128)
+    chkNotIsOdd(chk, "FFFFFFFFFFFFFFFFFA", 256)
+
+  tst "operator `isEven`":
+    chkNotIsOdd(chk, "0", 8)
+    chkNotIsOdd(chk, "0", 16)
+    chkNotIsOdd(chk, "0", 32)
+    chkNotIsOdd(chk, "0", 64)
+    chkNotIsOdd(chk, "0", 128)
+    chkNotIsOdd(chk, "0", 256)
+
+    chkNotIsOdd(chk, "4", 8)
+    chkNotIsOdd(chk, "4", 16)
+    chkNotIsOdd(chk, "4", 32)
+    chkNotIsOdd(chk, "4", 64)
+    chkNotIsOdd(chk, "4", 128)
+    chkNotIsOdd(chk, "4", 256)
+
+    chkNotIsOdd(chk, "A", 8)
+    chkNotIsOdd(chk, "AAA", 16)
+    chkNotIsOdd(chk, "AAAA", 32)
+    chkNotIsOdd(chk, "FFFFFA", 64)
+    chkNotIsOdd(chk, "FFFFFFFFFFFFFFA", 128)
+    chkNotIsOdd(chk, "FFFFFFFFFFFFFFFFFA", 256)
+
+  tst "operator not `isEven`":
+    chkIsOdd(chk, "1", 8)
+    chkIsOdd(chk, "1", 16)
+    chkIsOdd(chk, "1", 32)
+    chkIsOdd(chk, "1", 64)
+    chkIsOdd(chk, "1", 128)
+    chkIsOdd(chk, "1", 256)
+
+    chkIsOdd(chk, "FF", 8)
+    chkIsOdd(chk, "FFF", 16)
+    chkIsOdd(chk, "FFFFF", 32)
+    chkIsOdd(chk, "FFFFFF", 64)
+    chkIsOdd(chk, "FFFFFFFFFFFFFFF", 128)
+    chkIsOdd(chk, "FFFFFFFFFFFFFFFFFF", 256)
+
+static:
+  testComparison(doAssert, ctTest)
+
+suite "Wider signed int comparison coverage":
+  testComparison(check, test)
+
 suite "Signed int - Testing comparison operators":
   let
     a = 10'i16.stint(16)

--- a/tests/test_int_comparison.nim
+++ b/tests/test_int_comparison.nim
@@ -13,31 +13,31 @@ template chkLT(chk: untyped, a, b: string, bits: int) =
   chk fromHex(Stint[bits], a) < fromHex(Stint[bits], b)
 
 template chknotLT(chk: untyped, a, b: string, bits: int) =
-  chk not(fromHex(Stint[bits], b) < fromHex(Stint[bits], a))
+  chk (not(fromHex(Stint[bits], b) < fromHex(Stint[bits], a)))
 
 template chkLTE(chk: untyped, a, b: string, bits: int) =
   chk fromHex(Stint[bits], a) <= fromHex(Stint[bits], b)
 
 template chknotLTE(chk: untyped, a, b: string, bits: int) =
-  chk not(fromHex(Stint[bits], b) <= fromHex(Stint[bits], a))
+  chk (not(fromHex(Stint[bits], b) <= fromHex(Stint[bits], a)))
 
 template chkEQ(chk: untyped, a, b: string, bits: int) =
   chk fromHex(Stint[bits], a) == fromHex(Stint[bits], b)
 
 template chknotEQ(chk: untyped, a, b: string, bits: int) =
-  chk not(fromHex(Stint[bits], a) == fromHex(Stint[bits], b))
+  chk (not(fromHex(Stint[bits], a) == fromHex(Stint[bits], b)))
 
 template chkisZero(chk: untyped, a: string, bits: int) =
   chk fromHex(Stint[bits], a).isZero()
 
 template chknotisZero(chk: untyped, a: string, bits: int) =
-  chk not fromHex(Stint[bits], a).isZero()
+  chk (not fromHex(Stint[bits], a).isZero())
 
 template chkisNegative(chk: untyped, a: string, bits: int) =
   chk fromHex(Stint[bits], a).isNegative()
 
 template chknotisNegative(chk: untyped, a: string, bits: int) =
-  chk not fromHex(Stint[bits], a).isNegative()
+  chk (not fromHex(Stint[bits], a).isNegative())
 
 template chkisOdd(chk: untyped, a: string, bits: int) =
   chk fromHex(Stint[bits], a).isOdd()
@@ -49,7 +49,7 @@ template chkisEven(chk: untyped, a: string, bits: int) =
   chk fromHex(Stint[bits], a).isEven()
 
 template chknotisEven(chk: untyped, a: string, bits: int) =
-  chk not fromHex(Stint[bits], a).isEven()
+  chk (not fromHex(Stint[bits], a).isEven())
 
 template ctTest(name: string, body: untyped) =
   body

--- a/tests/test_int_comparison.nim
+++ b/tests/test_int_comparison.nim
@@ -7,7 +7,7 @@
 #
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import ../stint, unittest
+import ../stint, unittest, test_helpers
 
 template chkLT(chk: untyped, a, b: string, bits: int) =
   chk fromHex(Stint[bits], a) < fromHex(Stint[bits], b)
@@ -50,10 +50,6 @@ template chkisEven(chk: untyped, a: string, bits: int) =
 
 template chknotisEven(chk: untyped, a: string, bits: int) =
   chk (not fromHex(Stint[bits], a).isEven())
-
-template ctTest(name: string, body: untyped) =
-  body
-  echo "[OK] compile time ", name
 
 template testComparison(chk, tst: untyped) =
   tst "operator `LT`":
@@ -377,7 +373,7 @@ template testComparison(chk, tst: untyped) =
     chkIsOdd(chk, "FFFFFFFFFFFFFFFFFF", 256)
 
 static:
-  testComparison(doAssert, ctTest)
+  testComparison(ctCheck, ctTest)
 
 suite "Wider signed int comparison coverage":
   testComparison(check, test)

--- a/tests/test_int_muldiv.nim
+++ b/tests/test_int_muldiv.nim
@@ -9,6 +9,211 @@
 
 import ../stint, unittest
 
+template chkMul(chk: untyped, a, b, c: string, bits: int) =
+  chk (fromHex(Stint[bits], a) * fromHex(Stint[bits], b)) == fromHex(Stint[bits], c)
+
+template chkDiv(chk: untyped, a, b, c: string, bits: int) =
+  chk (fromHex(Stint[bits], a) div fromHex(Stint[bits], b)) == fromHex(Stint[bits], c)
+
+template chkMod(chk: untyped, a, b, c: string, bits: int) =
+  chk (fromHex(Stint[bits], a) mod fromHex(Stint[bits], b)) == fromHex(Stint[bits], c)
+
+template chkDivMod(chk: untyped, a, b, c, d: string, bits: int) =
+  chk divmod(fromHex(Stint[bits], a), fromHex(Stint[bits], b)) == (fromHex(Stint[bits], c), fromHex(Stint[bits], d))
+
+template ctTest(name: string, body: untyped) =
+  body
+  echo "[OK] compile time ", name
+
+template testMuldiv(chk, tst: untyped) =
+  tst "operator `mul`":
+    chkMul(chk, "0", "3", "0", 8)
+    chkMul(chk, "1", "3", "3", 8)
+    chkMul(chk, "F0", "3", "D0", 8)
+    chkMul(chk, "FF", "FF", "1", 8)
+
+    chkMul(chk, "0", "3", "0", 16)
+    chkMul(chk, "1", "3", "3", 16)
+    chkMul(chk, "F0", "3", "2D0", 16)
+    chkMul(chk, "F000", "3", "D000", 16)
+    chkMul(chk, "FFFF", "FFFF", "1", 16)
+
+    chkMul(chk, "0", "3", "0", 32)
+    chkMul(chk, "1", "3", "3", 32)
+    chkMul(chk, "F0", "3", "2D0", 32)
+    chkMul(chk, "F000", "3", "2D000", 32)
+    chkMul(chk, "F0000000", "3", "D0000000", 32)
+    chkMul(chk, "FFFFFFFF", "FFFFFFFF", "1", 32)
+
+    chkMul(chk, "0", "3", "0", 64)
+    chkMul(chk, "1", "3", "3", 64)
+    chkMul(chk, "F0", "3", "2D0", 64)
+    chkMul(chk, "F000", "3", "2D000", 64)
+    chkMul(chk, "F0000000", "3", "2D0000000", 64)
+    chkMul(chk, "F000000000000000", "3", "D000000000000000", 64)
+    chkMul(chk, "FFFFFFFFFFFFFFFF", "FFFFFFFFFFFFFFFF", "1", 64)
+
+    chkMul(chk, "0", "3", "0", 128)
+    chkMul(chk, "1", "3", "3", 128)
+    chkMul(chk, "F0", "3", "2D0", 128)
+    chkMul(chk, "F000", "3", "2D000", 128)
+    chkMul(chk, "F0000000", "3", "2D0000000", 128)
+    chkMul(chk, "F000000000000000", "3", "2D000000000000000", 128)
+    chkMul(chk, "F0000000000000000000000000000000", "3", "D0000000000000000000000000000000", 128)
+    chkMul(chk, "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "1", 128)
+
+  tst "operator `div`":
+    chkDiv(chk, "0", "3", "0", 8)
+    chkDiv(chk, "1", "3", "0", 8)
+    chkDiv(chk, "3", "3", "1", 8)
+    chkDiv(chk, "3", "1", "3", 8)
+    chkDiv(chk, "FF", "3", "0", 8)
+    chkDiv(chk, "0F", "FF", "F1", 8)
+    chkDiv(chk, "FF", "FF", "1", 8)
+
+    chkDiv(chk, "0", "3", "0", 16)
+    chkDiv(chk, "1", "3", "0", 16)
+    chkDiv(chk, "3", "3", "1", 16)
+    chkDiv(chk, "3", "1", "3", 16)
+    chkDiv(chk, "FF", "3", "55", 16)
+    chkDiv(chk, "0F", "FF", "0", 16)
+    chkDiv(chk, "FF", "FF", "1", 16)
+    chkDiv(chk, "FFFF", "3", "0", 16)
+    chkDiv(chk, "0F", "FFFF", "FFF1", 16)
+    chkDiv(chk, "FFFF", "FFFF", "1", 16)
+
+
+    chkDiv(chk, "0", "3", "0", 32)
+    chkDiv(chk, "1", "3", "0", 32)
+    chkDiv(chk, "3", "3", "1", 32)
+    chkDiv(chk, "3", "1", "3", 32)
+    chkDiv(chk, "FF", "3", "55", 32)
+    chkDiv(chk, "0F", "FF", "0", 32)
+    chkDiv(chk, "FF", "FF", "1", 32)
+    chkDiv(chk, "FFFF", "3", "5555", 32)
+    chkDiv(chk, "0F", "FFFFFFFF", "FFFFFFF1", 32)
+    chkDiv(chk, "FFFFFFFF", "FFFFFFFF", "1", 32)
+
+    chkDiv(chk, "0", "3", "0", 64)
+    chkDiv(chk, "1", "3", "0", 64)
+    chkDiv(chk, "3", "3", "1", 64)
+    chkDiv(chk, "3", "1", "3", 64)
+    chkDiv(chk, "FF", "3", "55", 64)
+    chkDiv(chk, "0F", "FF", "0", 64)
+    chkDiv(chk, "FF", "FF", "1", 64)
+    chkDiv(chk, "FFFF", "3", "5555", 64)
+    chkDiv(chk, "0F", "FFFFFFFFFFFFFFFF", "FFFFFFFFFFFFFFF1", 64)
+    chkDiv(chk, "FFFFFFFFFFFFFFFF", "FFFFFFFFFFFFFFFFF", "1", 64)
+
+    chkDiv(chk, "0", "3", "0", 128)
+    chkDiv(chk, "1", "3", "0", 128)
+    chkDiv(chk, "3", "3", "1", 128)
+    chkDiv(chk, "3", "1", "3", 128)
+    chkDiv(chk, "FF", "3", "55", 128)
+    chkDiv(chk, "0F", "FF", "0", 128)
+    chkDiv(chk, "FF", "FF", "1", 128)
+    chkDiv(chk, "FFFF", "3", "5555", 128)
+    chkDiv(chk, "0F", "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF1", 128)
+    chkDiv(chk, "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "1", 128)
+
+  tst "operator `mod`":
+    chkMod(chk, "0", "3", "0", 8)
+    chkMod(chk, "1", "3", "1", 8)
+    chkMod(chk, "3", "3", "0", 8)
+    chkMod(chk, "3", "1", "0", 8)
+    chkMod(chk, "FF", "3", "FF", 8)
+    chkMod(chk, "FF", "4", "FF", 8)
+    chkMod(chk, "FF", "FF", "0", 8)
+    chkMod(chk, "0F", "FC", "3", 8)
+
+    chkMod(chk, "0", "3", "0", 16)
+    chkMod(chk, "1", "3", "1", 16)
+    chkMod(chk, "3", "3", "0", 16)
+    chkMod(chk, "3", "1", "0", 16)
+    chkMod(chk, "FFFF", "3", "FFFF", 16)
+    chkMod(chk, "FFFF", "4", "FFFF", 16)
+    chkMod(chk, "FFFF", "FFFF", "0", 16)
+    chkMod(chk, "0F", "FFFC", "3", 16)
+
+    chkMod(chk, "0", "3", "0", 32)
+    chkMod(chk, "1", "3", "1", 32)
+    chkMod(chk, "3", "3", "0", 32)
+    chkMod(chk, "3", "1", "0", 32)
+    chkMod(chk, "FFFFFFFF", "3", "FFFFFFFF", 32)
+    chkMod(chk, "FFFFFFFF", "4", "FFFFFFFF", 32)
+    chkMod(chk, "FFFFFFFF", "FFFFFFFF", "0", 32)
+    chkMod(chk, "0F", "FFFFFFFC", "3", 32)
+
+    chkMod(chk, "0", "3", "0", 64)
+    chkMod(chk, "1", "3", "1", 64)
+    chkMod(chk, "3", "3", "0", 64)
+    chkMod(chk, "3", "1", "0", 64)
+    chkMod(chk, "FFFFFFFFFFFFFFFF", "3", "FFFFFFFFFFFFFFFF", 64)
+    chkMod(chk, "FFFFFFFFFFFFFFFF", "4", "FFFFFFFFFFFFFFFF", 64)
+    chkMod(chk, "FFFFFFFFFFFFFFFF", "FFFFFFFFFFFFFFFF", "0", 64)
+    chkMod(chk, "0F", "FFFFFFFFFFFFFFFC", "3", 64)
+
+    chkMod(chk, "0", "3", "0", 128)
+    chkMod(chk, "1", "3", "1", 128)
+    chkMod(chk, "3", "3", "0", 128)
+    chkMod(chk, "3", "1", "0", 128)
+    chkMod(chk, "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "3", "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", 128)
+    chkMod(chk, "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "4", "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", 128)
+    chkMod(chk, "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "0", 128)
+    chkMod(chk, "0F", "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC", "3", 128)
+
+  tst "operator `divmod`":
+    chkDivMod(chk, "0", "3", "0", "0", 8)
+    chkDivMod(chk, "1", "3", "0", "1", 8)
+    chkDivMod(chk, "3", "3", "1", "0", 8)
+    chkDivMod(chk, "3", "1", "3", "0", 8)
+    chkDivMod(chk, "FF", "3", "0", "FF", 8)
+    chkDivMod(chk, "FF", "4", "0", "FF", 8)
+    chkDivMod(chk, "FF", "FF", "1", "0", 8)
+    chkDivMod(chk, "0F", "FC", "FD", "3", 8)
+
+    chkDivMod(chk, "0", "3", "0", "0", 16)
+    chkDivMod(chk, "1", "3", "0", "1", 16)
+    chkDivMod(chk, "3", "3", "1", "0", 16)
+    chkDivMod(chk, "3", "1", "3", "0", 16)
+    chkDivMod(chk, "FFFF", "3", "0", "FFFF", 16)
+    chkDivMod(chk, "FFFF", "4", "0", "FFFF", 16)
+    chkDivMod(chk, "FFFF", "FFFF", "1", "0", 16)
+    chkDivMod(chk, "0F", "FFFC", "FFFD", "3", 16)
+
+    chkDivMod(chk, "0", "3", "0", "0", 32)
+    chkDivMod(chk, "1", "3", "0", "1", 32)
+    chkDivMod(chk, "3", "3", "1", "0", 32)
+    chkDivMod(chk, "3", "1", "3", "0", 32)
+    chkDivMod(chk, "FFFFFFFF", "3", "0", "FFFFFFFF", 32)
+    chkDivMod(chk, "FFFFFFFF", "4", "0", "FFFFFFFF", 32)
+    chkDivMod(chk, "FFFFFFFF", "FFFFFFFF", "1", "0", 32)
+    chkDivMod(chk, "0F", "FFFFFFFC", "FFFFFFFD", "3", 32)
+
+    chkDivMod(chk, "0", "3", "0", "0", 64)
+    chkDivMod(chk, "1", "3", "0", "1", 64)
+    chkDivMod(chk, "3", "3", "1", "0", 64)
+    chkDivMod(chk, "3", "1", "3", "0", 64)
+    chkDivMod(chk, "FFFFFFFFFFFFFFFF", "3", "0", "FFFFFFFFFFFFFFFF", 64)
+    chkDivMod(chk, "FFFFFFFFFFFFFFFF", "4", "0", "FFFFFFFFFFFFFFFF", 64)
+    chkDivMod(chk, "FFFFFFFFFFFFFFFF", "FFFFFFFFFFFFFFFF", "1", "0", 64)
+    chkDivMod(chk, "0F", "FFFFFFFFFFFFFFFC", "FFFFFFFFFFFFFFFD", "3", 64)
+
+    chkDivMod(chk, "0", "3", "0", "0", 128)
+    chkDivMod(chk, "1", "3", "0", "1", 128)
+    chkDivMod(chk, "3", "3", "1", "0", 128)
+    chkDivMod(chk, "3", "1", "3", "0", 128)
+    chkDivMod(chk, "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "3", "0", "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", 128)
+    chkDivMod(chk, "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "4", "0", "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", 128)
+    chkDivMod(chk, "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "1", "0", 128)
+    chkDivMod(chk, "0F", "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC", "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD", "3", 128)
+
+static:
+  testMuldiv(doAssert, ctTest)
+
+suite "Wider signed int muldiv coverage":
+  testMuldiv(check, test)
+#[
 suite "Testing signed int multiplication implementation":
   test "Multiplication with result fitting in low half":
 
@@ -119,3 +324,4 @@ suite "Testing signed int division and modulo implementation":
 
     check: q == 123456789123456789'i64
     check: r == 0'i64
+]#

--- a/tests/test_int_muldiv.nim
+++ b/tests/test_int_muldiv.nim
@@ -7,7 +7,7 @@
 #
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import ../stint, unittest
+import ../stint, unittest, test_helpers
 
 template chkMul(chk: untyped, a, b, c: string, bits: int) =
   chk (fromHex(Stint[bits], a) * fromHex(Stint[bits], b)) == fromHex(Stint[bits], c)
@@ -20,10 +20,6 @@ template chkMod(chk: untyped, a, b, c: string, bits: int) =
 
 template chkDivMod(chk: untyped, a, b, c, d: string, bits: int) =
   chk divmod(fromHex(Stint[bits], a), fromHex(Stint[bits], b)) == (fromHex(Stint[bits], c), fromHex(Stint[bits], d))
-
-template ctTest(name: string, body: untyped) =
-  body
-  echo "[OK] compile time ", name
 
 template testMuldiv(chk, tst: untyped) =
   tst "operator `mul`":
@@ -209,11 +205,11 @@ template testMuldiv(chk, tst: untyped) =
     chkDivMod(chk, "0F", "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC", "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD", "3", 128)
 
 static:
-  testMuldiv(doAssert, ctTest)
+  testMuldiv(ctCheck, ctTest)
 
 suite "Wider signed int muldiv coverage":
   testMuldiv(check, test)
-#[
+
 suite "Testing signed int multiplication implementation":
   test "Multiplication with result fitting in low half":
 
@@ -324,4 +320,3 @@ suite "Testing signed int division and modulo implementation":
 
     check: q == 123456789123456789'i64
     check: r == 0'i64
-]#

--- a/tests/test_io.nim
+++ b/tests/test_io.nim
@@ -173,8 +173,9 @@ template testIO(chk, tst: untyped) =
     nativeStuint(chk, high(int64), 64)
 
     when sizeof(uint) == 4:
-      nativeStuint(chk, high(uint), 32)
-      nativeStuint(chk, low(uint), 32)
+      when (NimMajor, NimMinor, NimPatch) >= (1, 0, 0):
+        nativeStuint(chk, high(uint), 32)
+        nativeStuint(chk, low(uint), 32)
       nativeStuint(chk, high(int), 32)
     else:
       when (NimMajor, NimMinor, NimPatch) >= (1, 0, 0):
@@ -254,7 +255,8 @@ template testIO(chk, tst: untyped) =
     when sizeof(uint) == 4:
       nativeStint(chk, high(int), 32)
       nativeStint(chk, low(int), 32)
-      nativeStint(chk, low(uint), 32)
+      when (NimMajor, NimMinor, NimPatch) >= (1, 0, 0):
+        nativeStint(chk, low(uint), 32)
     else:
       nativeStint(chk, high(int), 64)
       nativeStint(chk, low(int), 64)

--- a/tests/test_io.nim
+++ b/tests/test_io.nim
@@ -9,249 +9,1229 @@
 
 import ../stint, unittest, strutils, math
 
-suite "Testing input and output procedures":
-  test "Creation from decimal strings":
-    block:
-      let a = "123456789".parse(Stint[64])
-      let b = 123456789.stint(64)
+template nativeStuint(chk, nint: untyped, bits: int) =
+  chk $(nint.stuint(bits)) == $(nint)
 
-      check: a == b
-      check: 123456789'i64 == cast[int64](a)
+template nativeStint(chk, nint: untyped, bits: int) =
+  chk $(nint.stint(bits)) == $(nint)
 
-    block:
-      let a = "123456789".parse(Stuint[64])
-      let b = 123456789.stuint(64)
+template chkTruncateStuint(chk, number, toType: untyped, bits: int) =
+  chk (number.stuint(bits)).truncate(toType) == toType(number)
 
-      check: a == b
-      check: 123456789'u64 == cast[uint64](a)
+template chkTruncateStint(chk, number, toType: untyped, bits: int) =
+  chk (number.stint(bits)).truncate(toType) == toType(number)
 
-    block:
-      let a = "-123456789".parse(Stint[64])
-      let b = (-123456789).stint(64)
+template chkTruncateStint(chk, number, toType: untyped, res: string, bits: int) =
+  block:
+    let x = (number.stint(bits)).truncate(toType).toHex()
+    chk "0x" & x == res
 
-      check: a == b
-      check: -123456789'i64 == cast[int64](a)
+template chkRoundtripStuint(chk: untyped, prefix, str: string, bits, radix: int) =
+  block:
+    let data = prefix & str
+    let x = parse(data, Stuint[bits], radix)
+    let y = x.toString(radix)
+    chk y == str
 
-  test "Creation from hex strings":
-    block:
-      let a = "0xFF".parse(Stint[64], radix = 16)
-      let b = 255.stint(64)
+template chkRoundtripStuint(chk: untyped, str: string, bits, radix: int) =
+  chkRoundtripStuint(chk, "", str, bits, radix)
 
-      check: a == b
-      check: 255'i64 == cast[int64](a)
+template chkRoundtripStint(chk: untyped, prefix, str: string, bits, radix: int) =
+  block:
+    let data = prefix & str
+    let x = parse(data, Stint[bits], radix)
+    let y = x.toString(radix)
+    chk y == str
 
-    block:
-      let a = "0xFF".parse(Stuint[64], radix = 16)
-      let b = 255.stuint(64)
+template chkRoundtripStint(chk: untyped, str: string, bits, radix: int) =
+  chkRoundtripStint(chk, "", str, bits, radix)
 
-      check: a == b
-      check: 255'u64 == cast[uint64](a)
+template chkRoundtripBin(chk, chkProc: untyped, bits, rep: int) =
+  chkProc(chk, "0", bits, 2)
+  chkProc(chk, repeat("1", rep), bits, 2)
+  chkProc(chk, repeat("1010", rep), bits, 2)
+  chkProc(chk, repeat("1111", rep), bits, 2)
+  chkProc(chk, repeat("11110000", rep), bits, 2)
+  chkProc(chk, repeat("10101010", rep), bits, 2)
+  chkProc(chk, repeat("1010101", rep), bits, 2)
+  chkProc(chk, repeat("11111111", rep), bits, 2)
 
-      let a2 = hexToUint[64]("0xFF")
-      check: a == a2
+template chkRoundtripHex(chk, chkProc: untyped, bits, rep: int) =
+  chkProc(chk, "0", bits, 16)
+  chkProc(chk, repeat("1", rep), bits, 16)
+  chkProc(chk, repeat("7", rep), bits, 16)
+  chkProc(chk, repeat("f", rep), bits, 16)
+  chkProc(chk, repeat("aa", rep), bits, 16)
+  chkProc(chk, repeat("ff", rep), bits, 16)
+  chkProc(chk, repeat("f0", rep), bits, 16)
 
-    block:
-      let a = "0xFFFF".parse(Stint[16], 16)
-      let b = (-1'i16).stint(16)
+template chkRoundtripOct(chk, chkProc: untyped, bits, rep: int) =
+  chkProc(chk, "0", bits, 8)
+  chkProc(chk, repeat("1", rep), bits, 8)
+  chkProc(chk, repeat("7", rep), bits, 8)
+  chkProc(chk, repeat("177", rep), bits, 8)
 
-      check: a == b
-      check: -1'i16 == cast[int16](a)
+template chkRoundtripDec(chk, chkProc: untyped, bits, rep: int) =
+  chkProc(chk, "0", bits, 10)
+  chkProc(chk, repeat("1", rep), bits, 10)
+  chkProc(chk, repeat("9", rep), bits, 10)
 
-  test "Conversion to decimal strings":
-    block:
-      let a = 1234567891234567890.stint(128)
-      check: a.toString == "1234567891234567890"
-      check: $a == "1234567891234567890"
+func toByteArray(x: static[string]): auto {.compileTime.} =
+  var ret: array[x.len, byte]
+  for i, b in x: ret[i] = byte(b)
+  ret
 
-    block:
-      let a = 1234567891234567890.stuint(128)
-      check: a.toString == "1234567891234567890"
-      check: $a == "1234567891234567890"
+template chkRoundtripBE(chk: untyped, str: string, bits: int) =
+  block:
+    const data = toByteArray(str)
+    var x: Stuint[bits]
+    initFromBytesBE(x, data)
+    let y = toByteArrayBE(x)
+    chk y == data
 
-    block:
-      let a = (-1234567891234567890).stint(128)
-      check: a.toString == "-1234567891234567890"
-      check: $a == "-1234567891234567890"
+template chkCTvsRT(chk: untyped, num: untyped, bits: int) =
+  block:
+    let x = stuint(num, bits)
+    let y = toByteArrayBE(x)
+    const xx = stuint(num, bits)
+    const yy = toByteArrayBE(xx)
+    chk y == yy
 
-  test "Conversion to hex strings":
-    block:
-      let a = 0x1234567890ABCDEF.stint(128)
-      check: a.toHex.toUpperAscii == "1234567890ABCDEF"
+template chkDumpHex(chk: untyped, BE, LE: string, bits: int) =
+  block:
+    let data = BE
+    let x = fromHex(Stuint[bits], data)
+    chk dumpHex(x, bigEndian) == data
+    chk dumpHex(x, littleEndian) == LE
 
-    block:
-      let a = 0x1234567890ABCDEF.stuint(128)
-      check: a.toHex.toUpperAscii == "1234567890ABCDEF"
+template ctTest(name: string, body: untyped) =
+  body
+  echo "[OK] compile time ", name
 
-    # TODO: negative hex
+template testIO(chk, tst: untyped) =
+  tst "[stuint] Creation from native ints":
+    nativeStuint(chk, 0, 8)
+    nativeStuint(chk, 0'u8, 8)
+    nativeStuint(chk, 0xFF'u16, 8)
+    nativeStuint(chk, 0xFF'u32, 8)
+    nativeStuint(chk, 0xFF'u64, 8)
+    nativeStuint(chk, 0'i8, 8)
+    nativeStuint(chk, 0xFF'i16, 8)
+    nativeStuint(chk, 0xFF'i32, 8)
+    nativeStuint(chk, 0xFF'i64, 8)
+    nativeStuint(chk, high(uint8), 8)
+    nativeStuint(chk, low(uint8), 8)
+    nativeStuint(chk, high(int8), 8)
 
-  test "Hex dump":
-    block:
-      let a = 0x1234'i32.stint(32)
-      check: a.dumpHex(bigEndian).toUpperAscii == "00001234"
+    nativeStuint(chk, 0, 16)
+    nativeStuint(chk, 0'u8, 16)
+    nativeStuint(chk, 0xFFFF'u32, 16)
+    nativeStuint(chk, 0xFFFF'u64, 16)
+    nativeStuint(chk, 0xFFFF'i32, 16)
+    nativeStuint(chk, 0xFFFF'i64, 16)
+    nativeStuint(chk, high(uint8), 16)
+    nativeStuint(chk, low(uint8), 16)
+    nativeStuint(chk, high(int8), 16)
+    nativeStuint(chk, 0'u16, 16)
+    nativeStuint(chk, high(uint16), 16)
+    nativeStuint(chk, low(uint16), 16)
+    nativeStuint(chk, high(int16), 16)
 
-    block:
-      let a = 0x1234'i32.stint(32)
-      check: a.dumpHex(littleEndian).toUpperAscii == "34120000"
+    nativeStuint(chk, 0, 32)
+    nativeStuint(chk, 0'u8, 32)
+    nativeStuint(chk, 0xFFFFFFFF'u64, 32)
+    nativeStuint(chk, 0xFFFFFFFF'i64, 32)
+    nativeStuint(chk, high(uint8), 32)
+    nativeStuint(chk, low(uint8), 32)
+    nativeStuint(chk, high(int8), 32)
+    nativeStuint(chk, 0'u16, 32)
+    nativeStuint(chk, high(uint16), 32)
+    nativeStuint(chk, low(uint16), 32)
+    nativeStuint(chk, high(int16), 32)
+    nativeStuint(chk, 0'u32, 32)
+    nativeStuint(chk, high(uint32), 32)
+    nativeStuint(chk, low(uint32), 32)
+    nativeStuint(chk, high(int32), 32)
 
-  test "Back and forth bigint conversion consistency":
-    block:
-      let s = "1234567890123456789012345678901234567890123456789"
-      let a = parse(s, StInt[512])
-      check: a.toString == s
-      check: $a == s
+    nativeStuint(chk, 0, 64)
+    nativeStuint(chk, 0'u8, 64)
+    nativeStuint(chk, high(uint8), 64)
+    nativeStuint(chk, low(uint8), 64)
+    nativeStuint(chk, high(int8), 64)
+    nativeStuint(chk, 0'u16, 64)
+    nativeStuint(chk, high(uint16), 64)
+    nativeStuint(chk, low(uint16), 64)
+    nativeStuint(chk, high(int16), 64)
+    nativeStuint(chk, 0'u32, 64)
+    nativeStuint(chk, high(uint32), 64)
+    nativeStuint(chk, low(uint32), 64)
+    nativeStuint(chk, high(int32), 64)
+    nativeStuint(chk, 0'u64, 64)
+    when (NimMajor, NimMinor, NimPatch) >= (1, 0, 0):
+      nativeStuint(chk, high(uint64), 64)
+      nativeStuint(chk, low(uint64), 64)
+    nativeStuint(chk, high(int64), 64)
 
-    block:
-      let s = "1234567890123456789012345678901234567890123456789"
-      let a = parse(s, StUInt[512])
-      check: a.toString == s
-      check: $a == s
-
-  test "Truncate: int, int64, uint, uint64":
-    block:
-      let x = 100.stuint(128)
-      check:
-        x.truncate(int) == 100
-        x.truncate(int64) == 100'i64
-        x.truncate(uint64) == 100'u64
-        x.truncate(uint) == 100'u
-    block:
-      let x = pow(2.stuint(128), 64) + 1
-      check:
-        # x.truncate(int) == 1 # This is undefined
-        # x.truncate(int64) == 1'i64 # This is undefined
-        x.truncate(uint64) == 1'u64
-        x.truncate(uint) == 1'u
-
-  test "toInt, toInt64, toUint, toUint64 - word size (32/64-it) specific":
-    when not defined(stint_test):
-      # stint_test forces word size of 32-bit
-      # while stint uses uint64 by default.
-      block:
-        let x = pow(2.stuint(128), 32) + 1
-        when sizeof(int) == 4: # 32-bit machines
-          check:
-            x.truncate(uint) == 1'u
-            x.truncate(uint64) == 2'u64^32 + 1
-        else:
-          check:
-            x.truncate(uint) == 2'u^32 + 1
-            x.truncate(uint64) == 2'u64^32 + 1
+    when sizeof(uint) == 4:
+      nativeStuint(chk, high(uint), 32)
+      nativeStuint(chk, low(uint), 32)
+      nativeStuint(chk, high(int), 32)
     else:
-      echo "Next test skipped when Stint forces uint32 backend in test mode"
+      when (NimMajor, NimMinor, NimPatch) >= (1, 0, 0):
+        nativeStuint(chk, high(uint), 64)
+        nativeStuint(chk, low(uint), 64)
+      nativeStuint(chk, high(int), 64)
 
-suite "Testing conversion functions: Hex, Bytes, Endianness using secp256k1 curve":
+    nativeStuint(chk, 0, 128)
+    nativeStuint(chk, 0'u8, 128)
+    nativeStuint(chk, high(uint8), 128)
+    nativeStuint(chk, low(uint8), 128)
+    nativeStuint(chk, high(int8), 128)
+    nativeStuint(chk, 0'u16, 128)
+    nativeStuint(chk, high(uint16), 128)
+    nativeStuint(chk, low(uint16), 128)
+    nativeStuint(chk, high(int16), 128)
+    nativeStuint(chk, 0'u32, 128)
+    nativeStuint(chk, high(uint32), 128)
+    nativeStuint(chk, low(uint32), 128)
+    nativeStuint(chk, high(int32), 128)
+    nativeStuint(chk, 0'u64, 128)
+    when (NimMajor, NimMinor, NimPatch) >= (1, 0, 0):
+      nativeStuint(chk, high(uint64), 128)
+      nativeStuint(chk, low(uint64), 128)
+    nativeStuint(chk, high(int64), 128)
 
-  let
-    SECPK1_N_HEX = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141".toLowerAscii
-    SECPK1_N = "115792089237316195423570985008687907852837564279074904382605163141518161494337".u256
-    SECPK1_N_BYTES = [byte(255), 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 254, 186, 174, 220, 230, 175, 72, 160, 59, 191, 210, 94, 140, 208, 54, 65, 65]
+  tst "[stint] Creation from native ints":
+    nativeStint(chk, 0, 8)
+    nativeStint(chk, 0'u8, 8)
+    nativeStint(chk, high(int8), 8)
+    nativeStint(chk, low(int8), 8)
+    nativeStint(chk, low(uint8), 8)
 
-  test "explicit conversions from basic types":
+    nativeStint(chk, 0, 16)
+    nativeStint(chk, 0'u8, 16)
+    nativeStint(chk, high(int8), 16)
+    nativeStint(chk, low(int8), 16)
+    nativeStint(chk, low(uint8), 16)
+    nativeStint(chk, 0'u16, 16)
+    nativeStint(chk, high(int16), 16)
+    nativeStint(chk, low(int16), 16)
+    nativeStint(chk, low(uint16), 16)
+
+    nativeStint(chk, 0, 32)
+    nativeStint(chk, 0'u8, 32)
+    nativeStint(chk, high(int8), 32)
+    nativeStint(chk, low(int8), 32)
+    nativeStint(chk, low(uint8), 32)
+    nativeStint(chk, 0'u16, 32)
+    nativeStint(chk, high(int16), 32)
+    nativeStint(chk, low(int16), 32)
+    nativeStint(chk, low(uint16), 32)
+    nativeStint(chk, 0'u32, 32)
+    nativeStint(chk, high(int32), 32)
+    nativeStint(chk, low(int32), 32)
+    nativeStint(chk, low(uint32), 32)
+
+    nativeStint(chk, 0, 64)
+    nativeStint(chk, 0'u8, 64)
+    nativeStint(chk, high(int8), 64)
+    nativeStint(chk, low(int8), 64)
+    nativeStint(chk, low(uint8), 64)
+    nativeStint(chk, 0'u16, 64)
+    nativeStint(chk, high(int16), 64)
+    nativeStint(chk, low(int16), 64)
+    nativeStint(chk, low(uint16), 64)
+    nativeStint(chk, 0'u32, 64)
+    nativeStint(chk, high(int32), 64)
+    nativeStint(chk, low(int32), 64)
+    nativeStint(chk, low(uint32), 64)
+    nativeStint(chk, 0'u64, 64)
+    nativeStint(chk, high(int64), 64)
+    nativeStint(chk, low(int64), 64)
+    when (NimMajor, NimMinor, NimPatch) >= (1, 0, 0):
+      nativeStint(chk, low(uint64), 64)
+
+    when sizeof(uint) == 4:
+      nativeStint(chk, high(int), 32)
+      nativeStint(chk, low(int), 32)
+      nativeStint(chk, low(uint), 32)
+    else:
+      nativeStint(chk, high(int), 64)
+      nativeStint(chk, low(int), 64)
+      when (NimMajor, NimMinor, NimPatch) >= (1, 0, 0):
+        nativeStint(chk, low(uint), 64)
+
+    nativeStint(chk, 0, 128)
+    nativeStint(chk, 0'u8, 128)
+    nativeStint(chk, high(int8), 128)
+    nativeStint(chk, low(uint8), 128)
+    nativeStint(chk, 0'u16, 128)
+    nativeStint(chk, high(int16), 128)
+    nativeStint(chk, low(uint16), 128)
+    nativeStint(chk, 0'u32, 128)
+    nativeStint(chk, high(int32), 128)
+    nativeStint(chk, low(uint32), 128)
+    nativeStint(chk, 0'u64, 128)
+    nativeStint(chk, high(int64), 128)
+    when (NimMajor, NimMinor, NimPatch) >= (1, 0, 0):
+      nativeStint(chk, low(uint64), 128)
+
+    # TODO: bug #92
+    #nativeStint(chk, low(int8), 128)
+    #nativeStint(chk, low(int16), 128)
+    #nativeStint(chk, low(int32), 128)
+    #nativeStint(chk, low(int64), 128)
+
+  tst "[stuint] truncate":
+    chkTruncateStuint(chk, low(uint8), uint8, 8)
+    chkTruncateStuint(chk, high(uint8), uint8, 8)
+    chkTruncateStuint(chk, high(int8), uint8, 8)
+    chkTruncateStuint(chk, high(int8), int8, 8)
+
+    chkTruncateStuint(chk, low(uint8), uint8, 16)
+    chkTruncateStuint(chk, high(uint8), uint8, 16)
+    chkTruncateStuint(chk, high(int8), uint8, 16)
+    chkTruncateStuint(chk, high(int8), int8, 16)
+
+    chkTruncateStuint(chk, low(uint8), uint16, 16)
+    chkTruncateStuint(chk, high(uint8), uint16, 16)
+    chkTruncateStuint(chk, high(int8), uint16, 16)
+    chkTruncateStuint(chk, high(int8), int16, 16)
+
+    chkTruncateStuint(chk, low(uint16), uint16, 16)
+    chkTruncateStuint(chk, high(uint16), uint16, 16)
+    chkTruncateStuint(chk, high(int16), uint16, 16)
+    chkTruncateStuint(chk, high(int16), int16, 16)
+
+    chkTruncateStuint(chk, low(uint8), uint8, 32)
+    chkTruncateStuint(chk, high(uint8), uint8, 32)
+    chkTruncateStuint(chk, high(int8), uint8, 32)
+    chkTruncateStuint(chk, high(int8), int8, 32)
+
+    chkTruncateStuint(chk, low(uint8), uint16, 32)
+    chkTruncateStuint(chk, high(uint8), uint16, 32)
+    chkTruncateStuint(chk, high(int8), uint16, 32)
+    chkTruncateStuint(chk, high(int8), int16, 32)
+
+    chkTruncateStuint(chk, low(uint16), uint16, 32)
+    chkTruncateStuint(chk, high(uint16), uint16, 32)
+    chkTruncateStuint(chk, high(int16), uint16, 32)
+    chkTruncateStuint(chk, high(int16), int16, 32)
+
+    chkTruncateStuint(chk, low(uint8), uint32, 32)
+    chkTruncateStuint(chk, high(uint8), uint32, 32)
+    chkTruncateStuint(chk, high(int8), uint32, 32)
+    chkTruncateStuint(chk, high(int8), int32, 32)
+
+    chkTruncateStuint(chk, low(uint16), uint32, 32)
+    chkTruncateStuint(chk, high(uint16), uint32, 32)
+    chkTruncateStuint(chk, high(int16), uint32, 32)
+    chkTruncateStuint(chk, high(int16), int32, 32)
+
+    chkTruncateStuint(chk, low(uint32), uint32, 32)
+    chkTruncateStuint(chk, high(uint32), uint32, 32)
+    chkTruncateStuint(chk, high(int32), uint32, 32)
+    chkTruncateStuint(chk, high(int32), int32, 32)
+
+    chkTruncateStuint(chk, low(uint8), uint8, 64)
+    chkTruncateStuint(chk, high(uint8), uint8, 64)
+    chkTruncateStuint(chk, high(int8), uint8, 64)
+    chkTruncateStuint(chk, high(int8), int8, 64)
+
+    chkTruncateStuint(chk, low(uint8), uint16, 64)
+    chkTruncateStuint(chk, high(uint8), uint16, 64)
+    chkTruncateStuint(chk, high(int8), uint16, 64)
+    chkTruncateStuint(chk, high(int8), int16, 64)
+
+    chkTruncateStuint(chk, low(uint16), uint16, 64)
+    chkTruncateStuint(chk, high(uint16), uint16, 64)
+    chkTruncateStuint(chk, high(int16), uint16, 64)
+    chkTruncateStuint(chk, high(int16), int16, 64)
+
+    chkTruncateStuint(chk, low(uint8), uint32, 64)
+    chkTruncateStuint(chk, high(uint8), uint32, 64)
+    chkTruncateStuint(chk, high(int8), uint32, 64)
+    chkTruncateStuint(chk, high(int8), int32, 64)
+
+    chkTruncateStuint(chk, low(uint16), uint32, 64)
+    chkTruncateStuint(chk, high(uint16), uint32, 64)
+    chkTruncateStuint(chk, high(int16), uint32, 64)
+    chkTruncateStuint(chk, high(int16), int32, 64)
+
+    chkTruncateStuint(chk, low(uint32), uint32, 64)
+    chkTruncateStuint(chk, high(uint32), uint32, 64)
+    chkTruncateStuint(chk, high(int32), uint32, 64)
+    chkTruncateStuint(chk, high(int32), int32, 64)
+
+    chkTruncateStuint(chk, low(uint8), uint64, 64)
+    chkTruncateStuint(chk, high(uint8), uint64, 64)
+    chkTruncateStuint(chk, high(int8), uint64, 64)
+    chkTruncateStuint(chk, high(int8), int64, 64)
+
+    chkTruncateStuint(chk, low(uint16), uint64, 64)
+    chkTruncateStuint(chk, high(uint16), uint64, 64)
+    chkTruncateStuint(chk, high(int16), uint64, 64)
+    chkTruncateStuint(chk, high(int16), int64, 64)
+
+    chkTruncateStuint(chk, low(uint32), uint64, 64)
+    chkTruncateStuint(chk, high(uint32), uint64, 64)
+    chkTruncateStuint(chk, high(int32), uint64, 64)
+    chkTruncateStuint(chk, high(int32), int64, 64)
+
+    when (NimMajor, NimMinor, NimPatch) >= (1, 0, 0):
+      chkTruncateStuint(chk, low(uint64), uint64, 64)
+      chkTruncateStuint(chk, high(uint64), uint64, 64)
+    chkTruncateStuint(chk, high(int64), uint64, 64)
+    chkTruncateStuint(chk, high(int64), int64, 64)
+
+    chkTruncateStuint(chk, low(uint8), uint8, 128)
+    chkTruncateStuint(chk, high(uint8), uint8, 128)
+    chkTruncateStuint(chk, high(int8), uint8, 128)
+    chkTruncateStuint(chk, high(int8), int8, 128)
+
+    chkTruncateStuint(chk, low(uint8), uint16, 128)
+    chkTruncateStuint(chk, high(uint8), uint16, 128)
+    chkTruncateStuint(chk, high(int8), uint16, 128)
+    chkTruncateStuint(chk, high(int8), int16, 128)
+
+    chkTruncateStuint(chk, low(uint16), uint16, 128)
+    chkTruncateStuint(chk, high(uint16), uint16, 128)
+    chkTruncateStuint(chk, high(int16), uint16, 128)
+    chkTruncateStuint(chk, high(int16), int16, 128)
+
+    chkTruncateStuint(chk, low(uint8), uint32, 128)
+    chkTruncateStuint(chk, high(uint8), uint32, 128)
+    chkTruncateStuint(chk, high(int8), uint32, 128)
+    chkTruncateStuint(chk, high(int8), int32, 128)
+
+    chkTruncateStuint(chk, low(uint16), uint32, 128)
+    chkTruncateStuint(chk, high(uint16), uint32, 128)
+    chkTruncateStuint(chk, high(int16), uint32, 128)
+    chkTruncateStuint(chk, high(int16), int32, 128)
+
+    chkTruncateStuint(chk, low(uint32), uint32, 128)
+    chkTruncateStuint(chk, high(uint32), uint32, 128)
+    chkTruncateStuint(chk, high(int32), uint32, 128)
+    chkTruncateStuint(chk, high(int32), int32, 128)
+
+    chkTruncateStuint(chk, low(uint8), uint64, 128)
+    chkTruncateStuint(chk, high(uint8), uint64, 128)
+    chkTruncateStuint(chk, high(int8), uint64, 128)
+    chkTruncateStuint(chk, high(int8), int64, 128)
+
+    chkTruncateStuint(chk, low(uint16), uint64, 128)
+    chkTruncateStuint(chk, high(uint16), uint64, 128)
+    chkTruncateStuint(chk, high(int16), uint64, 128)
+    chkTruncateStuint(chk, high(int16), int64, 128)
+
+    chkTruncateStuint(chk, low(uint32), uint64, 128)
+    chkTruncateStuint(chk, high(uint32), uint64, 128)
+    chkTruncateStuint(chk, high(int32), uint64, 128)
+    chkTruncateStuint(chk, high(int32), int64, 128)
+
+    when (NimMajor, NimMinor, NimPatch) >= (1, 0, 0):
+      chkTruncateStuint(chk, low(uint64), uint64, 128)
+      chkTruncateStuint(chk, high(uint64), uint64, 128)
+    chkTruncateStuint(chk, high(int64), uint64, 128)
+    chkTruncateStuint(chk, high(int64), int64, 128)
+
+  tst "[stint] truncate":
+    chkTruncateStint(chk, low(uint8), uint8, 8)
+    chkTruncateStint(chk, low(int8), int8, 8)
+    chkTruncateStint(chk, high(int8), uint8, 8)
+    chkTruncateStint(chk, high(int8), int8, 8)
+    chkTruncateStint(chk, low(int8), uint8, "0x80", 8)
+
+    chkTruncateStint(chk, low(uint8), uint8, 16)
+    chkTruncateStint(chk, low(int8), int8, 16)
+    chkTruncateStint(chk, high(int8), uint8, 16)
+    chkTruncateStint(chk, high(int8), int8, 16)
+    chkTruncateStint(chk, low(int8), uint8, "0x80", 16)
+
+    chkTruncateStint(chk, low(uint8), uint16, 16)
+    chkTruncateStint(chk, low(int8), int16, 16)
+    chkTruncateStint(chk, high(int8), uint16, 16)
+    chkTruncateStint(chk, high(int8), int16, 16)
+    chkTruncateStint(chk, low(int8), uint16, "0xFF80", 16)
+
+    chkTruncateStint(chk, low(uint16), uint16, 16)
+    chkTruncateStint(chk, low(int16), int16, 16)
+    chkTruncateStint(chk, high(int16), uint16, 16)
+    chkTruncateStint(chk, high(int16), int16, 16)
+    chkTruncateStint(chk, low(int16), uint16, "0x8000", 16)
+
+    chkTruncateStint(chk, low(uint8), uint8, 32)
+    chkTruncateStint(chk, low(int8), int8, 32)
+    chkTruncateStint(chk, high(int8), uint8, 32)
+    chkTruncateStint(chk, high(int8), int8, 32)
+    chkTruncateStint(chk, low(int8), uint8, "0x80", 32)
+
+    chkTruncateStint(chk, low(uint8), uint16, 32)
+    chkTruncateStint(chk, low(int8), int16, 32)
+    chkTruncateStint(chk, high(int8), uint16, 32)
+    chkTruncateStint(chk, high(int8), int16, 32)
+    chkTruncateStint(chk, low(int8), uint16, "0xFF80", 32)
+
+    chkTruncateStint(chk, low(uint16), uint16, 32)
+    chkTruncateStint(chk, low(int16), int16, 32)
+    chkTruncateStint(chk, high(int16), uint16, 32)
+    chkTruncateStint(chk, high(int16), int16, 32)
+    chkTruncateStint(chk, low(int16), uint16, "0x8000", 32)
+
+    chkTruncateStint(chk, low(uint8), uint32, 32)
+    chkTruncateStint(chk, low(int8), int32, 32)
+    chkTruncateStint(chk, high(int8), uint32, 32)
+    chkTruncateStint(chk, high(int8), int32, 32)
+    chkTruncateStint(chk, low(int8), uint32, "0xFFFFFF80", 32)
+
+    chkTruncateStint(chk, low(uint16), uint32, 32)
+    chkTruncateStint(chk, low(int16), int32, 32)
+    chkTruncateStint(chk, high(int16), uint32, 32)
+    chkTruncateStint(chk, high(int16), int32, 32)
+    chkTruncateStint(chk, low(int16), uint32, "0xFFFF8000", 32)
+
+    chkTruncateStint(chk, low(uint32), uint32, 32)
+    chkTruncateStint(chk, low(int32), int32, 32)
+    chkTruncateStint(chk, high(int32), uint32, 32)
+    chkTruncateStint(chk, high(int32), int32, 32)
+    chkTruncateStint(chk, low(int32), uint32, "0x80000000", 32)
+
+    chkTruncateStint(chk, low(uint8), uint8, 64)
+    chkTruncateStint(chk, low(int8), int8, 64)
+    chkTruncateStint(chk, high(int8), uint8, 64)
+    chkTruncateStint(chk, high(int8), int8, 64)
+    chkTruncateStint(chk, low(int8), uint8, "0x80", 64)
+
+    chkTruncateStint(chk, low(uint8), uint16, 64)
+    chkTruncateStint(chk, low(int8), int16, 64)
+    chkTruncateStint(chk, high(int8), uint16, 64)
+    chkTruncateStint(chk, high(int8), int16, 64)
+    chkTruncateStint(chk, low(int8), uint16, "0xFF80", 64)
+
+    chkTruncateStint(chk, low(uint16), uint16, 64)
+    chkTruncateStint(chk, low(int16), int16, 64)
+    chkTruncateStint(chk, high(int16), uint16, 64)
+    chkTruncateStint(chk, high(int16), int16, 64)
+    chkTruncateStint(chk, low(int16), uint16, "0x8000", 64)
+
+    chkTruncateStint(chk, low(uint8), uint32, 64)
+    chkTruncateStint(chk, low(int8), int32, 64)
+    chkTruncateStint(chk, high(int8), uint32, 64)
+    chkTruncateStint(chk, high(int8), int32, 64)
+    chkTruncateStint(chk, low(int8), uint32, "0xFFFFFF80", 64)
+
+    chkTruncateStint(chk, low(uint16), uint32, 64)
+    chkTruncateStint(chk, low(int16), int32, 64)
+    chkTruncateStint(chk, high(int16), uint32, 64)
+    chkTruncateStint(chk, high(int16), int32, 64)
+    chkTruncateStint(chk, low(int16), uint32, "0xFFFF8000", 64)
+
+    chkTruncateStint(chk, low(uint32), uint32, 64)
+    chkTruncateStint(chk, low(int32), int32, 64)
+    chkTruncateStint(chk, high(int32), uint32, 64)
+    chkTruncateStint(chk, high(int32), int32, 64)
+    chkTruncateStint(chk, low(int32), uint32, "0x80000000", 64)
+
+    chkTruncateStint(chk, low(uint8), uint64, 64)
+    chkTruncateStint(chk, low(int8), int64, 64)
+    chkTruncateStint(chk, high(int8), uint64, 64)
+    chkTruncateStint(chk, high(int8), int64, 64)
+    chkTruncateStint(chk, low(int8), uint64, "0xFFFFFFFFFFFFFF80", 64)
+
+    chkTruncateStint(chk, low(uint16), uint64, 64)
+    chkTruncateStint(chk, low(int16), int64, 64)
+    chkTruncateStint(chk, high(int16), uint64, 64)
+    chkTruncateStint(chk, high(int16), int64, 64)
+    chkTruncateStint(chk, low(int16), uint64, "0xFFFFFFFFFFFF8000", 64)
+
+    chkTruncateStint(chk, low(uint32), uint64, 64)
+    chkTruncateStint(chk, low(int32), int64, 64)
+    chkTruncateStint(chk, high(int32), uint64, 64)
+    chkTruncateStint(chk, high(int32), int64, 64)
+    chkTruncateStint(chk, low(int32), uint64, "0xFFFFFFFF80000000", 64)
+
+    when (NimMajor, NimMinor, NimPatch) >= (1, 0, 0):
+      chkTruncateStint(chk, low(uint64), uint64, 64)
+    chkTruncateStint(chk, low(int64), int64, 64)
+    chkTruncateStint(chk, high(int64), uint64, 64)
+    chkTruncateStint(chk, high(int64), int64, 64)
+    chkTruncateStint(chk, low(int64), uint64, "0x8000000000000000", 64)
+
+  tst "[stuint] parse - toString roundtrip":
+    chkRoundTripBin(chk, chkRoundTripStuint, 8, 1)
+
+    chkRoundTripBin(chk, chkRoundTripStuint, 16, 1)
+    chkRoundTripBin(chk, chkRoundTripStuint, 16, 2)
+
+    chkRoundTripBin(chk, chkRoundTripStuint, 32, 1)
+    chkRoundTripBin(chk, chkRoundTripStuint, 32, 2)
+    chkRoundTripBin(chk, chkRoundTripStuint, 32, 3)
+    chkRoundTripBin(chk, chkRoundTripStuint, 32, 4)
+
+    chkRoundTripBin(chk, chkRoundTripStuint, 64, 1)
+    chkRoundTripBin(chk, chkRoundTripStuint, 64, 2)
+    chkRoundTripBin(chk, chkRoundTripStuint, 64, 3)
+    chkRoundTripBin(chk, chkRoundTripStuint, 64, 4)
+    chkRoundTripBin(chk, chkRoundTripStuint, 64, 5)
+    chkRoundTripBin(chk, chkRoundTripStuint, 64, 6)
+    chkRoundTripBin(chk, chkRoundTripStuint, 64, 7)
+    chkRoundTripBin(chk, chkRoundTripStuint, 64, 8)
+
+    chkRoundTripBin(chk, chkRoundTripStuint, 128, 1)
+    chkRoundTripBin(chk, chkRoundTripStuint, 128, 2)
+    chkRoundTripBin(chk, chkRoundTripStuint, 128, 3)
+    chkRoundTripBin(chk, chkRoundTripStuint, 128, 4)
+    chkRoundTripBin(chk, chkRoundTripStuint, 128, 5)
+    chkRoundTripBin(chk, chkRoundTripStuint, 128, 6)
+    chkRoundTripBin(chk, chkRoundTripStuint, 128, 7)
+    chkRoundTripBin(chk, chkRoundTripStuint, 128, 8)
+    chkRoundTripBin(chk, chkRoundTripStuint, 128, 9)
+    chkRoundTripBin(chk, chkRoundTripStuint, 128, 10)
+    chkRoundTripBin(chk, chkRoundTripStuint, 128, 11)
+    chkRoundTripBin(chk, chkRoundTripStuint, 128, 12)
+    chkRoundTripBin(chk, chkRoundTripStuint, 128, 13)
+    chkRoundTripBin(chk, chkRoundTripStuint, 128, 14)
+    chkRoundTripBin(chk, chkRoundTripStuint, 128, 15)
+    chkRoundTripBin(chk, chkRoundTripStuint, 128, 16)
+
+    chkRoundTripHex(chk, chkRoundTripStuint, 8, 1)
+
+    chkRoundTripHex(chk, chkRoundTripStuint, 16, 1)
+    chkRoundTripHex(chk, chkRoundTripStuint, 16, 2)
+
+    chkRoundTripHex(chk, chkRoundTripStuint, 32, 1)
+    chkRoundTripHex(chk, chkRoundTripStuint, 32, 2)
+    chkRoundTripHex(chk, chkRoundTripStuint, 32, 3)
+    chkRoundTripHex(chk, chkRoundTripStuint, 32, 4)
+
+    chkRoundTripHex(chk, chkRoundTripStuint, 64, 1)
+    chkRoundTripHex(chk, chkRoundTripStuint, 64, 2)
+    chkRoundTripHex(chk, chkRoundTripStuint, 64, 3)
+    chkRoundTripHex(chk, chkRoundTripStuint, 64, 4)
+    chkRoundTripHex(chk, chkRoundTripStuint, 64, 5)
+    chkRoundTripHex(chk, chkRoundTripStuint, 64, 6)
+    chkRoundTripHex(chk, chkRoundTripStuint, 64, 7)
+    chkRoundTripHex(chk, chkRoundTripStuint, 64, 8)
+
+    chkRoundTripHex(chk, chkRoundTripStuint, 128, 1)
+    chkRoundTripHex(chk, chkRoundTripStuint, 128, 2)
+    chkRoundTripHex(chk, chkRoundTripStuint, 128, 3)
+    chkRoundTripHex(chk, chkRoundTripStuint, 128, 4)
+    chkRoundTripHex(chk, chkRoundTripStuint, 128, 5)
+    chkRoundTripHex(chk, chkRoundTripStuint, 128, 6)
+    chkRoundTripHex(chk, chkRoundTripStuint, 128, 7)
+    chkRoundTripHex(chk, chkRoundTripStuint, 128, 8)
+    chkRoundTripHex(chk, chkRoundTripStuint, 128, 9)
+    chkRoundTripHex(chk, chkRoundTripStuint, 128, 10)
+    chkRoundTripHex(chk, chkRoundTripStuint, 128, 11)
+    chkRoundTripHex(chk, chkRoundTripStuint, 128, 12)
+    chkRoundTripHex(chk, chkRoundTripStuint, 128, 13)
+    chkRoundTripHex(chk, chkRoundTripStuint, 128, 14)
+    chkRoundTripHex(chk, chkRoundTripStuint, 128, 15)
+    chkRoundTripHex(chk, chkRoundTripStuint, 128, 16)
+
+    chkRoundTripOct(chk, chkRoundTripStuint, 8, 1)
+    chkRoundtripStuint(chk, "377", 8, 8)
+
+    chkRoundTripOct(chk, chkRoundTripStuint, 16, 1)
+    chkRoundTripOct(chk, chkRoundTripStuint, 16, 2)
+    chkRoundtripStuint(chk, "377", 16, 8)
+    chkRoundtripStuint(chk, "177777", 16, 8)
+
+    chkRoundTripOct(chk, chkRoundTripStuint, 32, 1)
+    chkRoundTripOct(chk, chkRoundTripStuint, 32, 2)
+    chkRoundTripOct(chk, chkRoundTripStuint, 32, 3)
+    chkRoundtripStuint(chk, "377", 32, 8)
+    chkRoundtripStuint(chk, "177777", 32, 8)
+    chkRoundtripStuint(chk, "37777777777", 32, 8)
+
+    chkRoundTripOct(chk, chkRoundTripStuint, 64, 1)
+    chkRoundTripOct(chk, chkRoundTripStuint, 64, 2)
+    chkRoundTripOct(chk, chkRoundTripStuint, 64, 3)
+    chkRoundTripOct(chk, chkRoundTripStuint, 64, 4)
+    chkRoundTripOct(chk, chkRoundTripStuint, 64, 5)
+    chkRoundTripOct(chk, chkRoundTripStuint, 64, 6)
+    chkRoundTripOct(chk, chkRoundTripStuint, 64, 7)
+    chkRoundtripStuint(chk, "377", 64, 8)
+    chkRoundtripStuint(chk, "177777", 64, 8)
+    chkRoundtripStuint(chk, "37777777777", 64, 8)
+    chkRoundtripStuint(chk, "1777777777777777777777", 64, 8)
+
+    chkRoundTripOct(chk, chkRoundTripStuint, 128, 1)
+    chkRoundTripOct(chk, chkRoundTripStuint, 128, 2)
+    chkRoundTripOct(chk, chkRoundTripStuint, 128, 3)
+    chkRoundTripOct(chk, chkRoundTripStuint, 128, 4)
+    chkRoundTripOct(chk, chkRoundTripStuint, 128, 5)
+    chkRoundTripOct(chk, chkRoundTripStuint, 128, 6)
+    chkRoundTripOct(chk, chkRoundTripStuint, 128, 7)
+    chkRoundTripOct(chk, chkRoundTripStuint, 128, 8)
+    chkRoundTripOct(chk, chkRoundTripStuint, 128, 9)
+    chkRoundTripOct(chk, chkRoundTripStuint, 128, 10)
+    chkRoundTripOct(chk, chkRoundTripStuint, 128, 11)
+    chkRoundTripOct(chk, chkRoundTripStuint, 128, 12)
+    chkRoundTripOct(chk, chkRoundTripStuint, 128, 13)
+    chkRoundTripOct(chk, chkRoundTripStuint, 128, 14)
+    chkRoundtripStuint(chk, "377", 128, 8)
+    chkRoundtripStuint(chk, "177777", 128, 8)
+    chkRoundtripStuint(chk, "37777777777", 128, 8)
+    chkRoundtripStuint(chk, "1777777777777777777777", 128, 8)
+    chkRoundtripStuint(chk, "3777777777777777777777777777777777777777777", 128, 8)
+
+    chkRoundTripDec(chk, chkRoundTripStuint, 8, 1)
+    chkRoundtripStuint(chk, "255", 8, 10)
+
+    chkRoundTripDec(chk, chkRoundTripStuint, 16, 1)
+    chkRoundTripDec(chk, chkRoundTripStuint, 16, 2)
+    chkRoundtripStuint(chk, "255", 16, 10)
+    chkRoundtripStuint(chk, "65535", 16, 10)
+
+    chkRoundTripDec(chk, chkRoundTripStuint, 32, 1)
+    chkRoundTripDec(chk, chkRoundTripStuint, 32, 2)
+    chkRoundTripDec(chk, chkRoundTripStuint, 32, 3)
+    chkRoundtripStuint(chk, "255", 32, 10)
+    chkRoundtripStuint(chk, "65535", 32, 10)
+    chkRoundtripStuint(chk, "4294967295", 32, 10)
+
+    chkRoundTripDec(chk, chkRoundTripStuint, 64, 1)
+    chkRoundTripDec(chk, chkRoundTripStuint, 64, 2)
+    chkRoundTripDec(chk, chkRoundTripStuint, 64, 3)
+    chkRoundTripDec(chk, chkRoundTripStuint, 64, 4)
+    chkRoundTripDec(chk, chkRoundTripStuint, 64, 5)
+    chkRoundTripDec(chk, chkRoundTripStuint, 64, 6)
+    chkRoundTripDec(chk, chkRoundTripStuint, 64, 7)
+    chkRoundtripStuint(chk, "255", 64, 10)
+    chkRoundtripStuint(chk, "65535", 64, 10)
+    chkRoundtripStuint(chk, "4294967295", 64, 10)
+    chkRoundtripStuint(chk, "18446744073709551615", 64, 10)
+
+    chkRoundTripDec(chk, chkRoundTripStuint, 128, 1)
+    chkRoundTripDec(chk, chkRoundTripStuint, 128, 2)
+    chkRoundTripDec(chk, chkRoundTripStuint, 128, 3)
+    chkRoundTripDec(chk, chkRoundTripStuint, 128, 4)
+    chkRoundTripDec(chk, chkRoundTripStuint, 128, 5)
+    chkRoundTripDec(chk, chkRoundTripStuint, 128, 6)
+    chkRoundTripDec(chk, chkRoundTripStuint, 128, 7)
+    chkRoundTripDec(chk, chkRoundTripStuint, 128, 8)
+    chkRoundTripDec(chk, chkRoundTripStuint, 128, 9)
+    chkRoundTripDec(chk, chkRoundTripStuint, 128, 10)
+    chkRoundTripDec(chk, chkRoundTripStuint, 128, 11)
+    chkRoundTripDec(chk, chkRoundTripStuint, 128, 12)
+    chkRoundTripDec(chk, chkRoundTripStuint, 128, 13)
+    chkRoundTripDec(chk, chkRoundTripStuint, 128, 14)
+    chkRoundtripStuint(chk, "255", 128, 10)
+    chkRoundtripStuint(chk, "65535", 128, 10)
+    chkRoundtripStuint(chk, "4294967295", 128, 10)
+    chkRoundtripStuint(chk, "18446744073709551615", 128, 10)
+    chkRoundtripStuint(chk, "340282366920938463463374607431768211455", 128, 10)
+
+  tst "[stint] parse - toString roundtrip":
+    chkRoundTripBin(chk, chkRoundTripStint, 8, 1)
+    chkRoundtripStint(chk, "1" & repeat('0', 7), 8, 2)
+
+    chkRoundTripBin(chk, chkRoundTripStint, 16, 1)
+    chkRoundTripBin(chk, chkRoundTripStint, 16, 2)
+    chkRoundtripStint(chk, "1" & repeat('0', 15), 16, 2)
+
+    chkRoundTripBin(chk, chkRoundTripStint, 32, 1)
+    chkRoundTripBin(chk, chkRoundTripStint, 32, 2)
+    chkRoundTripBin(chk, chkRoundTripStint, 32, 3)
+    chkRoundTripBin(chk, chkRoundTripStint, 32, 4)
+    chkRoundtripStint(chk, "1" & repeat('0', 31), 32, 2)
+
+    chkRoundTripBin(chk, chkRoundTripStint, 64, 1)
+    chkRoundTripBin(chk, chkRoundTripStint, 64, 2)
+    chkRoundTripBin(chk, chkRoundTripStint, 64, 3)
+    chkRoundTripBin(chk, chkRoundTripStint, 64, 4)
+    chkRoundTripBin(chk, chkRoundTripStint, 64, 5)
+    chkRoundTripBin(chk, chkRoundTripStint, 64, 6)
+    chkRoundTripBin(chk, chkRoundTripStint, 64, 7)
+    chkRoundTripBin(chk, chkRoundTripStint, 64, 8)
+    chkRoundtripStint(chk, "1" & repeat('0', 63), 64, 2)
+
+    chkRoundTripBin(chk, chkRoundTripStint, 128, 1)
+    chkRoundTripBin(chk, chkRoundTripStint, 128, 2)
+    chkRoundTripBin(chk, chkRoundTripStint, 128, 3)
+    chkRoundTripBin(chk, chkRoundTripStint, 128, 4)
+    chkRoundTripBin(chk, chkRoundTripStint, 128, 5)
+    chkRoundTripBin(chk, chkRoundTripStint, 128, 6)
+    chkRoundTripBin(chk, chkRoundTripStint, 128, 7)
+    chkRoundTripBin(chk, chkRoundTripStint, 128, 8)
+    chkRoundTripBin(chk, chkRoundTripStint, 128, 9)
+    chkRoundTripBin(chk, chkRoundTripStint, 128, 10)
+    chkRoundTripBin(chk, chkRoundTripStint, 128, 11)
+    chkRoundTripBin(chk, chkRoundTripStint, 128, 12)
+    chkRoundTripBin(chk, chkRoundTripStint, 128, 13)
+    chkRoundTripBin(chk, chkRoundTripStint, 128, 14)
+    chkRoundTripBin(chk, chkRoundTripStint, 128, 15)
+    chkRoundTripBin(chk, chkRoundTripStint, 128, 16)
+    chkRoundtripStint(chk, "1" & repeat('0', 127), 128, 2)
+
+    chkRoundTripHex(chk, chkRoundTripStint, 8, 1)
+    chkRoundtripStint(chk, "8" & repeat('0', 1), 8, 16)
+
+    chkRoundTripHex(chk, chkRoundTripStint, 16, 1)
+    chkRoundTripHex(chk, chkRoundTripStint, 16, 2)
+    chkRoundtripStint(chk, "8" & repeat('0', 3), 16, 16)
+
+    chkRoundTripHex(chk, chkRoundTripStint, 32, 1)
+    chkRoundTripHex(chk, chkRoundTripStint, 32, 2)
+    chkRoundTripHex(chk, chkRoundTripStint, 32, 3)
+    chkRoundTripHex(chk, chkRoundTripStint, 32, 4)
+    chkRoundtripStint(chk, "8" & repeat('0', 7), 32, 16)
+
+    chkRoundTripHex(chk, chkRoundTripStint, 64, 1)
+    chkRoundTripHex(chk, chkRoundTripStint, 64, 2)
+    chkRoundTripHex(chk, chkRoundTripStint, 64, 3)
+    chkRoundTripHex(chk, chkRoundTripStint, 64, 4)
+    chkRoundTripHex(chk, chkRoundTripStint, 64, 5)
+    chkRoundTripHex(chk, chkRoundTripStint, 64, 6)
+    chkRoundTripHex(chk, chkRoundTripStint, 64, 7)
+    chkRoundTripHex(chk, chkRoundTripStint, 64, 8)
+    chkRoundtripStint(chk, "8" & repeat('0', 15), 64, 16)
+
+    chkRoundTripHex(chk, chkRoundTripStint, 128, 1)
+    chkRoundTripHex(chk, chkRoundTripStint, 128, 2)
+    chkRoundTripHex(chk, chkRoundTripStint, 128, 3)
+    chkRoundTripHex(chk, chkRoundTripStint, 128, 4)
+    chkRoundTripHex(chk, chkRoundTripStint, 128, 5)
+    chkRoundTripHex(chk, chkRoundTripStint, 128, 6)
+    chkRoundTripHex(chk, chkRoundTripStint, 128, 7)
+    chkRoundTripHex(chk, chkRoundTripStint, 128, 8)
+    chkRoundTripHex(chk, chkRoundTripStint, 128, 9)
+    chkRoundTripHex(chk, chkRoundTripStint, 128, 10)
+    chkRoundTripHex(chk, chkRoundTripStint, 128, 11)
+    chkRoundTripHex(chk, chkRoundTripStint, 128, 12)
+    chkRoundTripHex(chk, chkRoundTripStint, 128, 13)
+    chkRoundTripHex(chk, chkRoundTripStint, 128, 14)
+    chkRoundTripHex(chk, chkRoundTripStint, 128, 15)
+    chkRoundTripHex(chk, chkRoundTripStint, 128, 16)
+    chkRoundtripStint(chk, "8" & repeat('0', 31), 128, 16)
+
+    chkRoundTripOct(chk, chkRoundTripStint, 8, 1)
+    chkRoundtripStint(chk, "377", 8, 8)
+    chkRoundtripStint(chk, "200", 8, 8)
+
+    chkRoundTripOct(chk, chkRoundTripStint, 16, 1)
+    chkRoundTripOct(chk, chkRoundTripStint, 16, 2)
+    chkRoundtripStint(chk, "377", 16, 8)
+    chkRoundtripStint(chk, "200", 16, 8)
+    chkRoundtripStint(chk, "177777", 16, 8)
+    chkRoundtripStint(chk, "100000", 16, 8)
+
+    chkRoundTripOct(chk, chkRoundTripStint, 32, 1)
+    chkRoundTripOct(chk, chkRoundTripStint, 32, 2)
+    chkRoundTripOct(chk, chkRoundTripStint, 32, 3)
+    chkRoundtripStint(chk, "377", 32, 8)
+    chkRoundtripStint(chk, "200", 32, 8)
+    chkRoundtripStint(chk, "177777", 32, 8)
+    chkRoundtripStint(chk, "100000", 32, 8)
+    chkRoundtripStint(chk, "37777777777", 32, 8)
+    chkRoundtripStint(chk, "20000000000", 32, 8)
+
+    chkRoundTripOct(chk, chkRoundTripStint, 64, 1)
+    chkRoundTripOct(chk, chkRoundTripStint, 64, 2)
+    chkRoundTripOct(chk, chkRoundTripStint, 64, 3)
+    chkRoundTripOct(chk, chkRoundTripStint, 64, 4)
+    chkRoundTripOct(chk, chkRoundTripStint, 64, 5)
+    chkRoundTripOct(chk, chkRoundTripStint, 64, 6)
+    chkRoundTripOct(chk, chkRoundTripStint, 64, 7)
+    chkRoundtripStint(chk, "377", 64, 8)
+    chkRoundtripStint(chk, "200", 64, 8)
+    chkRoundtripStint(chk, "177777", 64, 8)
+    chkRoundtripStint(chk, "100000", 64, 8)
+    chkRoundtripStint(chk, "37777777777", 64, 8)
+    chkRoundtripStint(chk, "20000000000", 64, 8)
+    chkRoundtripStint(chk, "1777777777777777777777", 64, 8)
+    chkRoundtripStint(chk, "1000000000000000000000", 64, 8)
+
+    chkRoundTripOct(chk, chkRoundTripStint, 128, 1)
+    chkRoundTripOct(chk, chkRoundTripStint, 128, 2)
+    chkRoundTripOct(chk, chkRoundTripStint, 128, 3)
+    chkRoundTripOct(chk, chkRoundTripStint, 128, 4)
+    chkRoundTripOct(chk, chkRoundTripStint, 128, 5)
+    chkRoundTripOct(chk, chkRoundTripStint, 128, 6)
+    chkRoundTripOct(chk, chkRoundTripStint, 128, 7)
+    chkRoundTripOct(chk, chkRoundTripStint, 128, 8)
+    chkRoundTripOct(chk, chkRoundTripStint, 128, 9)
+    chkRoundTripOct(chk, chkRoundTripStint, 128, 10)
+    chkRoundTripOct(chk, chkRoundTripStint, 128, 11)
+    chkRoundTripOct(chk, chkRoundTripStint, 128, 12)
+    chkRoundTripOct(chk, chkRoundTripStint, 128, 13)
+    chkRoundTripOct(chk, chkRoundTripStint, 128, 14)
+    chkRoundtripStint(chk, "377", 128, 8)
+    chkRoundtripStint(chk, "200", 128, 8)
+    chkRoundtripStint(chk, "177777", 128, 8)
+    chkRoundtripStint(chk, "100000", 128, 8)
+    chkRoundtripStint(chk, "37777777777", 128, 8)
+    chkRoundtripStint(chk, "20000000000", 128, 8)
+    chkRoundtripStint(chk, "1777777777777777777777", 128, 8)
+    chkRoundtripStint(chk, "1000000000000000000000", 128, 8)
+    chkRoundtripStint(chk, "3777777777777777777777777777777777777777777", 128, 8)
+    chkRoundtripStint(chk, "2000000000000000000000000000000000000000000", 128, 8)
+
+    chkRoundTripDec(chk, chkRoundTripStint, 8, 1)
+    chkRoundtripStint(chk, "127", 8, 10)
+    chkRoundtripStint(chk, "-127", 8, 10)
+    # chkRoundtripStint(chk, "-128", 8, 10) # TODO: not supported yet
+
+    chkRoundTripDec(chk, chkRoundTripStint, 16, 1)
+    chkRoundTripDec(chk, chkRoundTripStint, 16, 2)
+    chkRoundtripStint(chk, "255", 16, 10)
+    chkRoundtripStint(chk, "127", 16, 10)
+    chkRoundtripStint(chk, "-128", 16, 10)
+    chkRoundtripStint(chk, "32767", 16, 10)
+    chkRoundtripStint(chk, "-32767", 16, 10)
+    #chkRoundtripStint(chk, "-32768", 16, 10) # TODO: not supported yet
+
+    chkRoundTripDec(chk, chkRoundTripStint, 32, 1)
+    chkRoundTripDec(chk, chkRoundTripStint, 32, 2)
+    chkRoundTripDec(chk, chkRoundTripStint, 32, 3)
+    chkRoundtripStint(chk, "255", 32, 10)
+    chkRoundtripStint(chk, "127", 32, 10)
+    chkRoundtripStint(chk, "-128", 32, 10)
+    chkRoundtripStint(chk, "32767", 32, 10)
+    chkRoundtripStint(chk, "-32768", 32, 10)
+    chkRoundtripStint(chk, "65535", 32, 10)
+    chkRoundtripStint(chk, "-2147483647", 32, 10)
+    #chkRoundtripStint(chk, "-2147483648", 32, 10) # TODO: not supported yet
+
+    chkRoundTripDec(chk, chkRoundTripStint, 64, 1)
+    chkRoundTripDec(chk, chkRoundTripStint, 64, 2)
+    chkRoundTripDec(chk, chkRoundTripStint, 64, 3)
+    chkRoundTripDec(chk, chkRoundTripStint, 64, 4)
+    chkRoundTripDec(chk, chkRoundTripStint, 64, 5)
+    chkRoundTripDec(chk, chkRoundTripStint, 64, 6)
+    chkRoundTripDec(chk, chkRoundTripStint, 64, 7)
+    chkRoundtripStint(chk, "255", 64, 10)
+    chkRoundtripStint(chk, "65535", 64, 10)
+    chkRoundtripStint(chk, "127", 64, 10)
+    chkRoundtripStint(chk, "-128", 64, 10)
+    chkRoundtripStint(chk, "32767", 64, 10)
+    chkRoundtripStint(chk, "-32768", 64, 10)
+    chkRoundtripStint(chk, "65535", 64, 10)
+    chkRoundtripStint(chk, "-2147483648", 64, 10)
+    chkRoundtripStint(chk, "4294967295", 64, 10)
+    chkRoundtripStint(chk, "-9223372036854775807", 64, 10)
+    #chkRoundtripStint(chk, "-9223372036854775808", 64, 10) # TODO: not supported yet
+
+    chkRoundTripDec(chk, chkRoundTripStint, 128, 1)
+    chkRoundTripDec(chk, chkRoundTripStint, 128, 2)
+    chkRoundTripDec(chk, chkRoundTripStint, 128, 3)
+    chkRoundTripDec(chk, chkRoundTripStint, 128, 4)
+    chkRoundTripDec(chk, chkRoundTripStint, 128, 5)
+    chkRoundTripDec(chk, chkRoundTripStint, 128, 6)
+    chkRoundTripDec(chk, chkRoundTripStint, 128, 7)
+    chkRoundTripDec(chk, chkRoundTripStint, 128, 8)
+    chkRoundTripDec(chk, chkRoundTripStint, 128, 9)
+    chkRoundTripDec(chk, chkRoundTripStint, 128, 10)
+    chkRoundTripDec(chk, chkRoundTripStint, 128, 11)
+    chkRoundTripDec(chk, chkRoundTripStint, 128, 12)
+    chkRoundTripDec(chk, chkRoundTripStint, 128, 13)
+    chkRoundTripDec(chk, chkRoundTripStint, 128, 14)
+    chkRoundtripStint(chk, "255", 128, 10)
+    chkRoundtripStint(chk, "65535", 128, 10)
+    chkRoundtripStint(chk, "4294967295", 128, 10)
+    chkRoundtripStint(chk, "18446744073709551615", 128, 10)
+    chkRoundtripStint(chk, "-170141183460469231731687303715884105727", 128, 10)
+    #chkRoundtripStint(chk, "-170141183460469231731687303715884105728", 128, 10) # TODO: not supported yet
+
+  tst "roundtrip initFromBytesBE and toByteArrayBE":
+    chkRoundtripBE(chk, "x", 8)
+    chkRoundtripBE(chk, "xy", 16)
+    chkRoundtripBE(chk, "xyzw", 32)
+    chkRoundtripBE(chk, "xyzwabcd", 64)
+    chkRoundtripBE(chk, "xyzwabcd12345678", 128)
+    chkRoundtripBE(chk, "xyzwabcd12345678kilimanjarohello", 256)
+
+  tst "dumpHex":
+    chkDumpHex(chk, "ab", "ab", 8)
+
+    chkDumpHex(chk, "00ab", "ab00", 16)
+    chkDumpHex(chk, "abcd", "cdab", 16)
+
+    chkDumpHex(chk, "000000ab", "ab000000", 32)
+    chkDumpHex(chk, "3412abcd", "cdab1234", 32)
+
+    chkDumpHex(chk, "00000000000000ab", "ab00000000000000", 64)
+    chkDumpHex(chk, "abcdef0012345678", "7856341200efcdab", 64)
+
+    chkDumpHex(chk, "abcdef0012345678abcdef1122334455", "5544332211efcdab7856341200efcdab", 128)
+
+static:
+  testIO(doAssert, ctTest)
+
+proc main() =
+  # Nim GC protests we are using too much global variables
+  # so put it in a proc
+  suite "Testing input and output procedures":
+    testIO(check, test)
+
+    # dumpHex
+
+    test "toByteArrayBE CT vs RT":
+      chkCTvsRT(check, 0xab'u8, 8)
+
+      chkCTvsRT(check, 0xab'u16, 16)
+      chkCTvsRT(check, 0xabcd'u16, 16)
+
+      chkCTvsRT(check, 0xab'u32, 32)
+      chkCTvsRT(check, 0xabcd'u32, 32)
+      chkCTvsRT(check, 0xabcdef12'u32, 32)
+
+      chkCTvsRT(check, 0xab'u64, 64)
+      chkCTvsRT(check, 0xabcd'u64, 64)
+      chkCTvsRT(check, 0xabcdef12'u64, 64)
+      chkCTvsRT(check, 0xabcdef12abcdef12'u64, 64)
+
+      chkCTvsRT(check, 0xab'u64, 128)
+      chkCTvsRT(check, 0xabcd'u64, 128)
+      chkCTvsRT(check, 0xabcdef12'u64, 128)
+      chkCTvsRT(check, 0xabcdef12abcdef12'u64, 128)
+
+    test "Creation from decimal strings":
+      block:
+        let a = "123456789".parse(Stint[64])
+        let b = 123456789.stint(64)
+
+        check: a == b
+        check: 123456789'i64 == cast[int64](a)
+
+      block:
+        let a = "123456789".parse(Stuint[64])
+        let b = 123456789.stuint(64)
+
+        check: a == b
+        check: 123456789'u64 == cast[uint64](a)
+
+      block:
+        let a = "-123456789".parse(Stint[64])
+        let b = (-123456789).stint(64)
+
+        check: a == b
+        check: -123456789'i64 == cast[int64](a)
+
+    test "Creation from hex strings":
+      block:
+        let a = "0xFF".parse(Stint[64], radix = 16)
+        let b = 255.stint(64)
+
+        check: a == b
+        check: 255'i64 == cast[int64](a)
+
+      block:
+        let a = "0xFF".parse(Stuint[64], radix = 16)
+        let b = 255.stuint(64)
+
+        check: a == b
+        check: 255'u64 == cast[uint64](a)
+
+        let a2 = hexToUint[64]("0xFF")
+        check: a == a2
+
+      block:
+        let a = "0xFFFF".parse(Stint[16], 16)
+        let b = (-1'i16).stint(16)
+
+        check: a == b
+        check: -1'i16 == cast[int16](a)
+
+    test "Conversion to decimal strings":
+      block:
+        let a = 1234567891234567890.stint(128)
+        check: a.toString == "1234567891234567890"
+        check: $a == "1234567891234567890"
+
+      block:
+        let a = 1234567891234567890.stuint(128)
+        check: a.toString == "1234567891234567890"
+        check: $a == "1234567891234567890"
+
+      block:
+        let a = (-1234567891234567890).stint(128)
+        check: a.toString == "-1234567891234567890"
+        check: $a == "-1234567891234567890"
+
+    test "Conversion to hex strings":
+      block:
+        let a = 0x1234567890ABCDEF.stint(128)
+        check: a.toHex.toUpperAscii == "1234567890ABCDEF"
+
+      block:
+        let a = 0x1234567890ABCDEF.stuint(128)
+        check: a.toHex.toUpperAscii == "1234567890ABCDEF"
+
+      # TODO: negative hex
+
+    test "Hex dump":
+      block:
+        let a = 0x1234'i32.stint(32)
+        check: a.dumpHex(bigEndian).toUpperAscii == "00001234"
+
+      block:
+        let a = 0x1234'i32.stint(32)
+        check: a.dumpHex(littleEndian).toUpperAscii == "34120000"
+
+    test "Back and forth bigint conversion consistency":
+      block:
+        let s = "1234567890123456789012345678901234567890123456789"
+        let a = parse(s, StInt[512])
+        check: a.toString == s
+        check: $a == s
+
+      block:
+        let s = "1234567890123456789012345678901234567890123456789"
+        let a = parse(s, StUInt[512])
+        check: a.toString == s
+        check: $a == s
+
+    test "Truncate: int, int64, uint, uint64":
+      block:
+        let x = 100.stuint(128)
+        check:
+          x.truncate(int) == 100
+          x.truncate(int64) == 100'i64
+          x.truncate(uint64) == 100'u64
+          x.truncate(uint) == 100'u
+      block:
+        let x = pow(2.stuint(128), 64) + 1
+        check:
+          # x.truncate(int) == 1 # This is undefined
+          # x.truncate(int64) == 1'i64 # This is undefined
+          x.truncate(uint64) == 1'u64
+          x.truncate(uint) == 1'u
+
+    test "toInt, toInt64, toUint, toUint64 - word size (32/64-it) specific":
+      when not defined(stint_test):
+        # stint_test forces word size of 32-bit
+        # while stint uses uint64 by default.
+        block:
+          let x = pow(2.stuint(128), 32) + 1
+          when sizeof(int) == 4: # 32-bit machines
+            check:
+              x.truncate(uint) == 1'u
+              x.truncate(uint64) == 2'u64^32 + 1
+          else:
+            check:
+              x.truncate(uint) == 2'u^32 + 1
+              x.truncate(uint64) == 2'u64^32 + 1
+      else:
+        echo "Next test skipped when Stint forces uint32 backend in test mode"
+
+  suite "Testing conversion functions: Hex, Bytes, Endianness using secp256k1 curve":
+
+    let
+      SECPK1_N_HEX = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141".toLowerAscii
+      SECPK1_N = "115792089237316195423570985008687907852837564279074904382605163141518161494337".u256
+      SECPK1_N_BYTES = [byte(255), 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 254, 186, 174, 220, 230, 175, 72, 160, 59, 191, 210, 94, 140, 208, 54, 65, 65]
+
+    test "explicit conversions from basic types":
+      type
+        UInt256 = Stuint[256]
+        Int128 = Stint[128]
+
+      let x = 10.uint16
+
+      check:
+        x.to(UInt256).bits == 256
+        x.to(Int128).bits == 128
+
+    test "hex -> uint256":
+      check: SECPK1_N_HEX.parse(Stuint[256], radix = 16) == SECPK1_N
+
+    test "uint256 -> hex":
+      check: SECPK1_N.dumpHex == SECPK1_N_HEX
+
+    test "hex -> big-endian array -> uint256":
+      check: readUintBE[256](SECPK1_N_BYTES) == SECPK1_N
+
+    test "uint256 -> minimal big-endian array -> uint256":
+      # test drive the conversion logic by testing the first 25 factorials:
+      var f = 1.stuint(256)
+      for i in 2 .. 25:
+        f = f * i.stuint(256)
+        let
+          bytes = f.toByteArrayBE
+          nonZeroBytes = significantBytesBE(bytes)
+          fRestored = Uint256.fromBytesBE(bytes.toOpenArray(bytes.len - nonZeroBytes,
+                                                            bytes.len - 1))
+        check f == fRestored
+
+    test "uint256 -> big-endian array -> hex":
+      check: SECPK1_N.toByteArrayBE == SECPK1_N_BYTES
+
+    # This is a sample of signatures generated with a known-good implementation of the ECDSA
+    # algorithm, which we use to test our ECC backends. If necessary, it can be generated from scratch
+    # with the following code:
+    #
+    # """python
+    # from devp2p import crypto
+    # from eth_utils import encode_hex
+    # msg = b'message'
+    # msghash = crypto.sha3(b'message')
+    # for secret in ['alice', 'bob', 'eve']:
+    #     print("'{}': dict(".format(secret))
+    #     privkey = crypto.mk_privkey(secret)
+    #     pubkey = crypto.privtopub(privkey)
+    #     print("    privkey='{}',".format(encode_hex(privkey)))
+    #     print("    pubkey='{}',".format(encode_hex(crypto.privtopub(privkey))))
+    #     ecc = crypto.ECCx(raw_privkey=privkey)
+    #     sig = ecc.sign(msghash)
+    #     print("    sig='{}',".format(encode_hex(sig)))
+    #     print("    raw_sig='{}')".format(crypto._decode_sig(sig)))
+    #     doAssert crypto.ecdsa_recover(msghash, sig) == pubkey
+    # """
+
     type
-      UInt256 = Stuint[256]
-      Int128 = Stint[128]
+      testKeySig = object
+        privkey*: string
+        pubkey*: string
+        raw_sig*: tuple[v: int, r, s: string]
+        serialized_sig*: string
 
-    let x = 10.uint16
-
-    check:
-      x.to(UInt256).bits == 256
-      x.to(Int128).bits == 128
-
-  test "hex -> uint256":
-    check: SECPK1_N_HEX.parse(Stuint[256], radix = 16) == SECPK1_N
-
-  test "uint256 -> hex":
-    check: SECPK1_N.dumpHex == SECPK1_N_HEX
-
-  test "hex -> big-endian array -> uint256":
-    check: readUintBE[256](SECPK1_N_BYTES) == SECPK1_N
-
-  test "uint256 -> minimal big-endian array -> uint256":
-    # test drive the conversion logic by testing the first 25 factorials:
-    var f = 1.stuint(256)
-    for i in 2 .. 25:
-      f = f * i.stuint(256)
-      let
-        bytes = f.toByteArrayBE
-        nonZeroBytes = significantBytesBE(bytes)
-        fRestored = Uint256.fromBytesBE(bytes.toOpenArray(bytes.len - nonZeroBytes,
-                                                          bytes.len - 1))
-      check f == fRestored
-
-  test "uint256 -> big-endian array -> hex":
-    check: SECPK1_N.toByteArrayBE == SECPK1_N_BYTES
-
-  # This is a sample of signatures generated with a known-good implementation of the ECDSA
-  # algorithm, which we use to test our ECC backends. If necessary, it can be generated from scratch
-  # with the following code:
-  #
-  # """python
-  # from devp2p import crypto
-  # from eth_utils import encode_hex
-  # msg = b'message'
-  # msghash = crypto.sha3(b'message')
-  # for secret in ['alice', 'bob', 'eve']:
-  #     print("'{}': dict(".format(secret))
-  #     privkey = crypto.mk_privkey(secret)
-  #     pubkey = crypto.privtopub(privkey)
-  #     print("    privkey='{}',".format(encode_hex(privkey)))
-  #     print("    pubkey='{}',".format(encode_hex(crypto.privtopub(privkey))))
-  #     ecc = crypto.ECCx(raw_privkey=privkey)
-  #     sig = ecc.sign(msghash)
-  #     print("    sig='{}',".format(encode_hex(sig)))
-  #     print("    raw_sig='{}')".format(crypto._decode_sig(sig)))
-  #     doAssert crypto.ecdsa_recover(msghash, sig) == pubkey
-  # """
-
-  type
-    testKeySig = object
-      privkey*: string
-      pubkey*: string
-      raw_sig*: tuple[v: int, r, s: string]
-      serialized_sig*: string
-
-  let
-    alice = testKeySig(
-      privkey: "9c0257114eb9399a2985f8e75dad7600c5d89fe3824ffa99ec1c3eb8bf3b0501",
-      pubkey: "5eed5fa3a67696c334762bb4823e585e2ee579aba3558d9955296d6c04541b426078dbd48d74af1fd0c72aa1a05147cf17be6b60bdbed6ba19b08ec28445b0ca",
-      raw_sig: (
-        v: 1,
-        r: "B20E2EA5D3CBAA83C1E0372F110CF12535648613B479B64C1A8C1A20C5021F38", # Decimal "80536744857756143861726945576089915884233437828013729338039544043241440681784",
-        s: "0434D07EC5795E3F789794351658E80B7FAF47A46328F41E019D7B853745CDFD"  # Decimal "1902566422691403459035240420865094128779958320521066670269403689808757640701"
-      ),
-      serialized_sig: "b20e2ea5d3cbaa83c1e0372f110cf12535648613b479b64c1a8c1a20c5021f380434d07ec5795e3f789794351658e80b7faf47a46328f41e019d7b853745cdfd01"
-    )
-
-    bob = testKeySig(
-      privkey: "38e47a7b719dce63662aeaf43440326f551b8a7ee198cee35cb5d517f2d296a2",
-      pubkey: "347746ccb908e583927285fa4bd202f08e2f82f09c920233d89c47c79e48f937d049130e3d1c14cf7b21afefc057f71da73dec8e8ff74ff47dc6a574ccd5d570",
-      raw_sig: (
-        v: 1,
-        r: "5C48EA4F0F2257FA23BD25E6FCB0B75BBE2FF9BBDA0167118DAB2BB6E31BA76E", # Decimal "41741612198399299636429810387160790514780876799439767175315078161978521003886",
-        s: "691DBDAF2A231FC9958CD8EDD99507121F8184042E075CF10F98BA88ABFF1F36"  # Decimal "47545396818609319588074484786899049290652725314938191835667190243225814114102"
+    let
+      alice = testKeySig(
+        privkey: "9c0257114eb9399a2985f8e75dad7600c5d89fe3824ffa99ec1c3eb8bf3b0501",
+        pubkey: "5eed5fa3a67696c334762bb4823e585e2ee579aba3558d9955296d6c04541b426078dbd48d74af1fd0c72aa1a05147cf17be6b60bdbed6ba19b08ec28445b0ca",
+        raw_sig: (
+          v: 1,
+          r: "B20E2EA5D3CBAA83C1E0372F110CF12535648613B479B64C1A8C1A20C5021F38", # Decimal "80536744857756143861726945576089915884233437828013729338039544043241440681784",
+          s: "0434D07EC5795E3F789794351658E80B7FAF47A46328F41E019D7B853745CDFD"  # Decimal "1902566422691403459035240420865094128779958320521066670269403689808757640701"
         ),
-        serialized_sig: "5c48ea4f0f2257fa23bd25e6fcb0b75bbe2ff9bbda0167118dab2bb6e31ba76e691dbdaf2a231fc9958cd8edd99507121f8184042e075cf10f98ba88abff1f3601"
+        serialized_sig: "b20e2ea5d3cbaa83c1e0372f110cf12535648613b479b64c1a8c1a20c5021f380434d07ec5795e3f789794351658e80b7faf47a46328f41e019d7b853745cdfd01"
       )
 
-    eve = testKeySig(
-      privkey: "876be0999ed9b7fc26f1b270903ef7b0c35291f89407903270fea611c85f515c",
-      pubkey: "c06641f0d04f64dba13eac9e52999f2d10a1ff0ca68975716b6583dee0318d91e7c2aed363ed22edeba2215b03f6237184833fd7d4ad65f75c2c1d5ea0abecc0",
-      raw_sig: (
-        v: 0,
-        r: "BABEEFC5082D3CA2E0BC80532AB38F9CFB196FB9977401B2F6A98061F15ED603", # Decimal "84467545608142925331782333363288012579669270632210954476013542647119929595395",
-        s: "603D0AF084BF906B2CDF6CDDE8B2E1C3E51A41AF5E9ADEC7F3643B3F1AA2AADF"  # Decimal "43529886636775750164425297556346136250671451061152161143648812009114516499167"
-        ),
-        serialized_sig: "babeefc5082d3ca2e0bc80532ab38f9cfb196fb9977401b2f6a98061f15ed603603d0af084bf906b2cdf6cdde8b2e1c3e51a41af5e9adec7f3643b3f1aa2aadf00"
-    )
+      bob = testKeySig(
+        privkey: "38e47a7b719dce63662aeaf43440326f551b8a7ee198cee35cb5d517f2d296a2",
+        pubkey: "347746ccb908e583927285fa4bd202f08e2f82f09c920233d89c47c79e48f937d049130e3d1c14cf7b21afefc057f71da73dec8e8ff74ff47dc6a574ccd5d570",
+        raw_sig: (
+          v: 1,
+          r: "5C48EA4F0F2257FA23BD25E6FCB0B75BBE2FF9BBDA0167118DAB2BB6E31BA76E", # Decimal "41741612198399299636429810387160790514780876799439767175315078161978521003886",
+          s: "691DBDAF2A231FC9958CD8EDD99507121F8184042E075CF10F98BA88ABFF1F36"  # Decimal "47545396818609319588074484786899049290652725314938191835667190243225814114102"
+          ),
+          serialized_sig: "5c48ea4f0f2257fa23bd25e6fcb0b75bbe2ff9bbda0167118dab2bb6e31ba76e691dbdaf2a231fc9958cd8edd99507121f8184042e075cf10f98ba88abff1f3601"
+        )
 
-  test "Alice signature":
-    check: alice.raw_sig.r.parse(Stuint[256], 16) == "80536744857756143861726945576089915884233437828013729338039544043241440681784".u256
-    check: alice.raw_sig.s.parse(Stuint[256], 16) == "1902566422691403459035240420865094128779958320521066670269403689808757640701".u256
+      eve = testKeySig(
+        privkey: "876be0999ed9b7fc26f1b270903ef7b0c35291f89407903270fea611c85f515c",
+        pubkey: "c06641f0d04f64dba13eac9e52999f2d10a1ff0ca68975716b6583dee0318d91e7c2aed363ed22edeba2215b03f6237184833fd7d4ad65f75c2c1d5ea0abecc0",
+        raw_sig: (
+          v: 0,
+          r: "BABEEFC5082D3CA2E0BC80532AB38F9CFB196FB9977401B2F6A98061F15ED603", # Decimal "84467545608142925331782333363288012579669270632210954476013542647119929595395",
+          s: "603D0AF084BF906B2CDF6CDDE8B2E1C3E51A41AF5E9ADEC7F3643B3F1AA2AADF"  # Decimal "43529886636775750164425297556346136250671451061152161143648812009114516499167"
+          ),
+          serialized_sig: "babeefc5082d3ca2e0bc80532ab38f9cfb196fb9977401b2f6a98061f15ed603603d0af084bf906b2cdf6cdde8b2e1c3e51a41af5e9adec7f3643b3f1aa2aadf00"
+      )
 
-  test "Bob signature":
-    check: bob.raw_sig.r.parse(Stuint[256], 16) == "41741612198399299636429810387160790514780876799439767175315078161978521003886".u256
-    check: bob.raw_sig.s.parse(Stuint[256], 16) == "47545396818609319588074484786899049290652725314938191835667190243225814114102".u256
+    test "Alice signature":
+      check: alice.raw_sig.r.parse(Stuint[256], 16) == "80536744857756143861726945576089915884233437828013729338039544043241440681784".u256
+      check: alice.raw_sig.s.parse(Stuint[256], 16) == "1902566422691403459035240420865094128779958320521066670269403689808757640701".u256
 
-  test "Eve signature":
-    check: eve.raw_sig.r.parse(Stuint[256], 16) == "84467545608142925331782333363288012579669270632210954476013542647119929595395".u256
-    check: eve.raw_sig.s.parse(Stuint[256], 16) == "43529886636775750164425297556346136250671451061152161143648812009114516499167".u256
+    test "Bob signature":
+      check: bob.raw_sig.r.parse(Stuint[256], 16) == "41741612198399299636429810387160790514780876799439767175315078161978521003886".u256
+      check: bob.raw_sig.s.parse(Stuint[256], 16) == "47545396818609319588074484786899049290652725314938191835667190243225814114102".u256
+
+    test "Eve signature":
+      check: eve.raw_sig.r.parse(Stuint[256], 16) == "84467545608142925331782333363288012579669270632210954476013542647119929595395".u256
+      check: eve.raw_sig.s.parse(Stuint[256], 16) == "43529886636775750164425297556346136250671451061152161143648812009114516499167".u256
+
+main()

--- a/tests/test_io.nim
+++ b/tests/test_io.nim
@@ -7,7 +7,7 @@
 #
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import ../stint, unittest, strutils, math
+import ../stint, unittest, strutils, math, test_helpers
 
 template nativeStuint(chk, nint: untyped, bits: int) =
   chk $(nint.stuint(bits)) == $(nint)
@@ -103,10 +103,6 @@ template chkDumpHex(chk: untyped, BE, LE: string, bits: int) =
     let x = fromHex(Stuint[bits], data)
     chk dumpHex(x, bigEndian) == data
     chk dumpHex(x, littleEndian) == LE
-
-template ctTest(name: string, body: untyped) =
-  body
-  echo "[OK] compile time ", name
 
 template testIO(chk, tst: untyped) =
   tst "[stuint] Creation from native ints":
@@ -559,6 +555,67 @@ template testIO(chk, tst: untyped) =
     chkTruncateStint(chk, high(int64), int64, 64)
     chkTruncateStint(chk, low(int64), uint64, "0x8000000000000000", 64)
 
+    chkTruncateStint(chk, low(uint8), uint8, 128)
+    #chkTruncateStint(chk, low(int8), int8, 128) # TODO: bug #92
+    chkTruncateStint(chk, high(int8), uint8, 128)
+    chkTruncateStint(chk, high(int8), int8, 128)
+    #chkTruncateStint(chk, low(int8), uint8, "0x80", 128) # TODO: bug #92
+
+    chkTruncateStint(chk, low(uint8), uint16, 128)
+    #chkTruncateStint(chk, low(int8), int16, 128) # TODO: bug #92
+    chkTruncateStint(chk, high(int8), uint16, 128)
+    chkTruncateStint(chk, high(int8), int16, 128)
+    #chkTruncateStint(chk, low(int8), uint16, "0xFF80", 128) # TODO: bug #92
+
+    chkTruncateStint(chk, low(uint16), uint16, 128)
+    #chkTruncateStint(chk, low(int16), int16, 128) # TODO: bug #92
+    chkTruncateStint(chk, high(int16), uint16, 128)
+    chkTruncateStint(chk, high(int16), int16, 128)
+    #chkTruncateStint(chk, low(int16), uint16, "0x8000", 128) # TODO: bug #92
+
+    chkTruncateStint(chk, low(uint8), uint32, 128)
+    #chkTruncateStint(chk, low(int8), int32, 128) # TODO: bug #92
+    chkTruncateStint(chk, high(int8), uint32, 128)
+    chkTruncateStint(chk, high(int8), int32, 128)
+    #chkTruncateStint(chk, low(int8), uint32, "0xFFFFFF80", 128) # TODO: bug #92
+
+    chkTruncateStint(chk, low(uint16), uint32, 128)
+    #chkTruncateStint(chk, low(int16), int32, 128) # TODO: bug #92
+    chkTruncateStint(chk, high(int16), uint32, 128)
+    chkTruncateStint(chk, high(int16), int32, 128)
+    #chkTruncateStint(chk, low(int16), uint32, "0xFFFF8000", 128) # TODO: bug #92
+
+    chkTruncateStint(chk, low(uint32), uint32, 128)
+    #chkTruncateStint(chk, low(int32), int32, 128) # TODO: bug #92
+    chkTruncateStint(chk, high(int32), uint32, 128)
+    chkTruncateStint(chk, high(int32), int32, 128)
+    #chkTruncateStint(chk, low(int32), uint32, "0x80000000", 128) # TODO: bug #92
+
+    chkTruncateStint(chk, low(uint8), uint64, 128)
+    #chkTruncateStint(chk, low(int8), int64, 128) # TODO: bug #92
+    chkTruncateStint(chk, high(int8), uint64, 128)
+    chkTruncateStint(chk, high(int8), int64, 128)
+    #chkTruncateStint(chk, low(int8), uint64, "0xFFFFFFFFFFFFFF80", 128) # TODO: bug #92
+
+    chkTruncateStint(chk, low(uint16), uint64, 128)
+    #chkTruncateStint(chk, low(int16), int64, 128) # TODO: bug #92
+    chkTruncateStint(chk, high(int16), uint64, 128)
+    chkTruncateStint(chk, high(int16), int64, 128)
+    #chkTruncateStint(chk, low(int16), uint64, "0xFFFFFFFFFFFF8000", 128) # TODO: bug #92
+
+    chkTruncateStint(chk, low(uint32), uint64, 128)
+    #chkTruncateStint(chk, low(int32), int64, 128) # TODO: bug #92
+    chkTruncateStint(chk, high(int32), uint64, 128)
+    chkTruncateStint(chk, high(int32), int64, 128)
+    #chkTruncateStint(chk, low(int32), uint64, "0xFFFFFFFF80000000", 128) # TODO: bug #92
+
+    when (NimMajor, NimMinor, NimPatch) >= (1, 0, 0):
+      chkTruncateStint(chk, low(uint64), uint64, 128)
+    #chkTruncateStint(chk, low(int64), int64, 128) # TODO: bug #92
+    chkTruncateStint(chk, high(int64), uint64, 128)
+    chkTruncateStint(chk, high(int64), int64, 128)
+    #chkTruncateStint(chk, low(int64), uint64, "0x8000000000000000", 128) # TODO: bug #92
+
   tst "[stuint] parse - toString roundtrip":
     chkRoundTripBin(chk, chkRoundTripStuint, 8, 1)
 
@@ -960,7 +1017,7 @@ template testIO(chk, tst: untyped) =
     chkDumpHex(chk, "abcdef0012345678abcdef1122334455", "5544332211efcdab7856341200efcdab", 128)
 
 static:
-  testIO(doAssert, ctTest)
+  testIO(ctCheck, ctTest)
 
 proc main() =
   # Nim GC protests we are using too much global variables

--- a/tests/test_uint_addsub.nim
+++ b/tests/test_uint_addsub.nim
@@ -205,7 +205,7 @@ template testAddSub(chk, tst: untyped) =
 static:
   testAddSub(doAssert, ctTest)
 
-suite "Wider unsigned int coverage":
+suite "Wider unsigned int addsub coverage":
   testAddSub(check, test)
 
 suite "Testing unsigned int addition implementation":

--- a/tests/test_uint_addsub.nim
+++ b/tests/test_uint_addsub.nim
@@ -7,7 +7,7 @@
 #
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import ../stint, unittest
+import ../stint, unittest, test_helpers
 
 template chkAddition(chk, a, b, c, bits: untyped) =
   block:
@@ -32,10 +32,6 @@ template chkInplaceSubstraction(chk, a, b, c, bits: untyped) =
     var x = stuint(a, bits)
     x -= stuint(b, bits)
     chk x == stuint(c, bits)
-
-template ctTest(name: string, body: untyped) =
-  body
-  echo "[OK] compile time ", name
 
 template testAddSub(chk, tst: untyped) =
   tst "addition":
@@ -203,7 +199,7 @@ template testAddSub(chk, tst: untyped) =
       chkInplaceSubstraction(chk, high(uint64), high(uint64), 0'u64, 128)
 
 static:
-  testAddSub(doAssert, ctTest)
+  testAddSub(ctCheck, ctTest)
 
 suite "Wider unsigned int addsub coverage":
   testAddSub(check, test)

--- a/tests/test_uint_addsub.nim
+++ b/tests/test_uint_addsub.nim
@@ -9,6 +9,205 @@
 
 import ../stint, unittest
 
+template chkAddition(chk, a, b, c, bits: untyped) =
+  block:
+    let x = stuint(a, bits)
+    let y = stuint(b, bits)
+    chk x + y == stuint(c, bits)
+
+template chkInplaceAddition(chk, a, b, c, bits: untyped) =
+  block:
+    var x = stuint(a, bits)
+    x += stuint(b, bits)
+    chk x == stuint(c, bits)
+
+template chkSubstraction(chk, a, b, c, bits: untyped) =
+  block:
+    let x = stuint(a, bits)
+    let y = stuint(b, bits)
+    chk x - y == stuint(c, bits)
+
+template chkInplaceSubstraction(chk, a, b, c, bits: untyped) =
+  block:
+    var x = stuint(a, bits)
+    x -= stuint(b, bits)
+    chk x == stuint(c, bits)
+
+template ctTest(name: string, body: untyped) =
+  body
+  echo "[OK] compile time ", name
+
+template testAddSub(chk, tst: untyped) =
+  tst "addition":
+    chkAddition(chk, 0'u8, 0'u8, 0'u8, 8)
+    chkAddition(chk, high(uint8) - 17'u8, 17'u8, high(uint8), 8)
+    chkAddition(chk, low(uint8), 17'u8, low(uint8) + 17'u8, 8)
+
+    chkAddition(chk, 0'u8, 0'u8, 0'u8, 16)
+    chkAddition(chk, high(uint8) - 17'u8, 17'u8, high(uint8), 16)
+    chkAddition(chk, low(uint8), 17'u8, low(uint8) + 17'u8, 16)
+    chkAddition(chk, high(uint16) - 17'u16, 17'u16, high(uint16), 16)
+    chkAddition(chk, low(uint16), 17'u16, low(uint16) + 17'u16, 16)
+
+    chkAddition(chk, 0'u8, 0'u8, 0'u8, 32)
+    chkAddition(chk, high(uint8) - 17'u8, 17'u8, high(uint8), 32)
+    chkAddition(chk, low(uint8), 17'u8, low(uint8) + 17'u8, 32)
+    chkAddition(chk, high(uint16) - 17'u16, 17'u16, high(uint16), 32)
+    chkAddition(chk, low(uint16), 17'u16, low(uint16) + 17'u16, 32)
+    chkAddition(chk, high(uint32) - 17'u32, 17'u32, high(uint32), 32)
+    chkAddition(chk, low(uint32), 17'u32, low(uint32) + 17'u32, 32)
+
+    chkAddition(chk, 0'u8, 0'u8, 0'u8, 64)
+    chkAddition(chk, high(uint8) - 17'u8, 17'u8, high(uint8), 64)
+    chkAddition(chk, low(uint8), 17'u8, low(uint8) + 17'u8, 64)
+    chkAddition(chk, high(uint16) - 17'u16, 17'u16, high(uint16), 64)
+    chkAddition(chk, low(uint16), 17'u16, low(uint16) + 17'u16, 64)
+    chkAddition(chk, high(uint32) - 17'u32, 17'u32, high(uint32), 64)
+    chkAddition(chk, low(uint32), 17'u32, low(uint32) + 17'u32, 64)
+    when (NimMajor, NimMinor, NimPatch) >= (1, 0, 0):
+      chkAddition(chk, high(uint64) - 17'u64, 17'u64, high(uint64), 64)
+      chkAddition(chk, low(uint64), 17'u64, low(uint64) + 17'u64, 64)
+
+    chkAddition(chk, 0'u8, 0'u8, 0'u8, 128)
+    chkAddition(chk, high(uint8) - 17'u8, 17'u8, high(uint8), 128)
+    chkAddition(chk, low(uint8), 17'u8, low(uint8) + 17'u8, 128)
+    chkAddition(chk, high(uint16) - 17'u16, 17'u16, high(uint16), 128)
+    chkAddition(chk, low(uint16), 17'u16, low(uint16) + 17'u16, 128)
+    chkAddition(chk, high(uint32) - 17'u32, 17'u32, high(uint32), 128)
+    chkAddition(chk, low(uint32), 17'u32, low(uint32) + 17'u32, 128)
+    when (NimMajor, NimMinor, NimPatch) >= (1, 0, 0):
+      chkAddition(chk, high(uint64) - 17'u64, 17'u64, high(uint64), 128)
+      chkAddition(chk, low(uint64), 17'u64, low(uint64) + 17'u64, 128)
+
+  tst "inplace addition":
+    chkInplaceAddition(chk, 0'u8, 0'u8, 0'u8, 8)
+    chkInplaceAddition(chk, high(uint8) - 17'u8, 17'u8, high(uint8), 8)
+    chkInplaceAddition(chk, low(uint8) + 17'u8, 17'u8, low(uint8) + 34'u8, 8)
+
+    chkInplaceAddition(chk, 0'u8, 0'u8, 0'u8, 16)
+    chkInplaceAddition(chk, high(uint8) - 17'u8, 17'u8, high(uint8), 16)
+    chkInplaceAddition(chk, low(uint8) + 17'u8, 17'u8, low(uint8) + 34'u8, 16)
+    chkInplaceAddition(chk, high(uint16) - 17'u16, 17'u16, high(uint16), 16)
+    chkInplaceAddition(chk, low(uint16) + 17'u16, 17'u16, low(uint16) + 34'u16, 16)
+
+    chkInplaceAddition(chk, 0'u8, 0'u8, 0'u8, 32)
+    chkInplaceAddition(chk, high(uint8) - 17'u8, 17'u8, high(uint8), 32)
+    chkInplaceAddition(chk, low(uint8) + 17'u8, 17'u8, low(uint8) + 34'u8, 32)
+    chkInplaceAddition(chk, high(uint16) - 17'u16, 17'u16, high(uint16), 32)
+    chkInplaceAddition(chk, low(uint16) + 17'u16, 17'u16, low(uint16) + 34'u16, 32)
+    chkInplaceAddition(chk, high(uint32) - 17'u32, 17'u32, high(uint32), 32)
+    chkInplaceAddition(chk, low(uint32) + 17'u32, 17'u32, low(uint32) + 34'u32, 32)
+
+    chkInplaceAddition(chk, 0'u8, 0'u8, 0'u8, 64)
+    chkInplaceAddition(chk, high(uint8) - 17'u8, 17'u8, high(uint8), 64)
+    chkInplaceAddition(chk, low(uint8) + 17'u8, 17'u8, low(uint8) + 34'u8, 64)
+    chkInplaceAddition(chk, high(uint16) - 17'u16, 17'u16, high(uint16), 64)
+    chkInplaceAddition(chk, low(uint16) + 17'u16, 17'u16, low(uint16) + 34'u16, 64)
+    chkInplaceAddition(chk, high(uint32) - 17'u32, 17'u32, high(uint32), 64)
+    chkInplaceAddition(chk, low(uint32) + 17'u32, 17'u32, low(uint32) + 34'u32, 64)
+    when (NimMajor, NimMinor, NimPatch) >= (1, 0, 0):
+      chkInplaceAddition(chk, high(uint64) - 17'u64, 17'u64, high(uint64), 64)
+      chkInplaceAddition(chk, low(uint64) + 17'u64, 17'u64, low(uint64) + 34'u64, 64)
+
+    chkInplaceAddition(chk, 0'u8, 0'u8, 0'u8, 128)
+    chkInplaceAddition(chk, high(uint8) - 17'u8, 17'u8, high(uint8), 128)
+    chkInplaceAddition(chk, low(uint8) + 17'u8, 17'u8, low(uint8) + 34'u8, 128)
+    chkInplaceAddition(chk, high(uint16) - 17'u16, 17'u16, high(uint16), 128)
+    chkInplaceAddition(chk, low(uint16) + 17'u16, 17'u16, low(uint16) + 34'u16, 128)
+    chkInplaceAddition(chk, high(uint32) - 17'u32, 17'u32, high(uint32), 128)
+    chkInplaceAddition(chk, low(uint32) + 17'u32, 17'u32, low(uint32) + 34'u32, 128)
+    when (NimMajor, NimMinor, NimPatch) >= (1, 0, 0):
+      chkInplaceAddition(chk, high(uint64) - 17'u64, 17'u64, high(uint64), 128)
+      chkInplaceAddition(chk, low(uint64) + 17'u64, 17'u64, low(uint64) + 34'u64, 128)
+
+  tst "substraction":
+    chkSubstraction(chk, 0'u8, 0'u8, 0'u8, 8)
+    chkSubstraction(chk, high(uint8) - 17'u8, 17'u8, high(uint8) - 34'u8, 8)
+    chkSubstraction(chk, low(uint8) + 17'u8, 17'u8, low(uint8), 8)
+
+    chkSubstraction(chk, 0'u8, 0'u8, 0'u8, 16)
+    chkSubstraction(chk, high(uint8) - 17'u8, 17'u8, high(uint8) - 34'u8, 16)
+    chkSubstraction(chk, low(uint8) + 17'u8, 17'u8, low(uint8), 16)
+    chkSubstraction(chk, high(uint16) - 17'u16, 17'u16, high(uint16) - 34'u16, 16)
+    chkSubstraction(chk, low(uint16) + 17'u16, 17'u16, low(uint16), 16)
+
+    chkSubstraction(chk, 0'u8, 0'u8, 0'u8, 32)
+    chkSubstraction(chk, high(uint8) - 17'u8, 17'u8, high(uint8) - 34'u8, 32)
+    chkSubstraction(chk, low(uint8) + 17'u8, 17'u8, low(uint8), 32)
+    chkSubstraction(chk, high(uint16) - 17'u16, 17'u16, high(uint16) - 34'u16, 32)
+    chkSubstraction(chk, low(uint16) + 17'u16, 17'u16, low(uint16), 32)
+    chkSubstraction(chk, high(uint32) - 17'u32, 17'u32, high(uint32) - 34'u32, 32)
+    chkSubstraction(chk, low(uint32) + 17'u32, 17'u32, low(uint32), 32)
+
+    chkSubstraction(chk, 0'u8, 0'u8, 0'u8, 64)
+    chkSubstraction(chk, high(uint8) - 17'u8, 17'u8, high(uint8) - 34'u8, 64)
+    chkSubstraction(chk, low(uint8) + 17'u8, 17'u8, low(uint8), 64)
+    chkSubstraction(chk, high(uint16) - 17'u16, 17'u16, high(uint16) - 34'u16, 64)
+    chkSubstraction(chk, low(uint16) + 17'u16, 17'u16, low(uint16), 64)
+    chkSubstraction(chk, high(uint32) - 17'u32, 17'u32, high(uint32) - 34'u32, 64)
+    chkSubstraction(chk, low(uint32) + 17'u32, 17'u32, low(uint32), 64)
+    when (NimMajor, NimMinor, NimPatch) >= (1, 0, 0):
+      chkSubstraction(chk, high(uint64) - 17'u64, 17'u64, high(uint64) - 34'u64, 64)
+      chkSubstraction(chk, low(uint64) + 17'u64, 17'u64, low(uint64), 64)
+
+    chkSubstraction(chk, 0'u8, 0'u8, 0'u8, 128)
+    chkSubstraction(chk, high(uint8) - 17'u8, 17'u8, high(uint8) - 34'u8, 128)
+    chkSubstraction(chk, high(uint8), high(uint8), 0'u8, 128)
+    chkSubstraction(chk, high(uint16) - 17'u16, 17'u16, high(uint16) - 34'u16, 128)
+    chkSubstraction(chk, high(uint16), high(uint16), 0'u16, 128)
+    chkSubstraction(chk, high(uint32) - 17'u32, 17'u32, high(uint32) - 34'u32, 128)
+    chkSubstraction(chk, high(uint32), high(uint32), 0'u32, 128)
+    when (NimMajor, NimMinor, NimPatch) >= (1, 0, 0):
+      chkSubstraction(chk, high(uint64) - 17'u64, 17'u64, high(uint64) - 34'u64, 128)
+      chkSubstraction(chk, high(uint64), high(uint64), 0'u64, 128)
+
+  tst "inplace substraction":
+    chkInplaceSubstraction(chk, 0'u8, 0'u8, 0'u8, 8)
+    chkInplaceSubstraction(chk, high(uint8) - 17'u8, 17'u8, high(uint8) - 34'u8, 8)
+    chkInplaceSubstraction(chk, low(uint8) + 17'u8, 17'u8, low(uint8), 8)
+
+    chkInplaceSubstraction(chk, 0'u8, 0'u8, 0'u8, 16)
+    chkInplaceSubstraction(chk, high(uint8) - 17'u8, 17'u8, high(uint8) - 34'u8, 16)
+    chkInplaceSubstraction(chk, low(uint8) + 17'u8, 17'u8, low(uint8), 16)
+    chkInplaceSubstraction(chk, high(uint16) - 17'u16, 17'u16, high(uint16) - 34'u16, 16)
+    chkInplaceSubstraction(chk, low(uint16) + 17'u16, 17'u16, low(uint16), 16)
+
+    chkInplaceSubstraction(chk, 0'u8, 0'u8, 0'u8, 32)
+    chkInplaceSubstraction(chk, high(uint8) - 17'u8, 17'u8, high(uint8) - 34'u8, 32)
+    chkInplaceSubstraction(chk, low(uint8) + 17'u8, 17'u8, low(uint8), 32)
+    chkInplaceSubstraction(chk, high(uint16) - 17'u16, 17'u16, high(uint16) - 34'u16, 32)
+    chkInplaceSubstraction(chk, low(uint16) + 17'u16, 17'u16, low(uint16), 32)
+    chkInplaceSubstraction(chk, high(uint32) - 17'u32, 17'u32, high(uint32) - 34'u32, 32)
+    chkInplaceSubstraction(chk, low(uint32) + 17'u32, 17'u32, low(uint32), 32)
+
+    chkInplaceSubstraction(chk, 0'u8, 0'u8, 0'u8, 64)
+    chkInplaceSubstraction(chk, high(uint8) - 17'u8, 17'u8, high(uint8) - 34'u8, 64)
+    chkInplaceSubstraction(chk, low(uint8) + 17'u8, 17'u8, low(uint8), 64)
+    chkInplaceSubstraction(chk, high(uint16) - 17'u16, 17'u16, high(uint16) - 34'u16, 64)
+    chkInplaceSubstraction(chk, low(uint16) + 17'u16, 17'u16, low(uint16), 64)
+    chkInplaceSubstraction(chk, high(uint32) - 17'u32, 17'u32, high(uint32) - 34'u32, 64)
+    chkInplaceSubstraction(chk, low(uint32) + 17'u32, 17'u32, low(uint32), 64)
+    when (NimMajor, NimMinor, NimPatch) >= (1, 0, 0):
+      chkInplaceSubstraction(chk, high(uint64) - 17'u64, 17'u64, high(uint64) - 34'u64, 64)
+      chkInplaceSubstraction(chk, low(uint64) + 17'u64, 17'u64, low(uint64), 64)
+
+    chkInplaceSubstraction(chk, 0'u8, 0'u8, 0'u8, 128)
+    chkInplaceSubstraction(chk, high(uint8) - 17'u8, 17'u8, high(uint8) - 34'u8, 128)
+    chkInplaceSubstraction(chk, high(uint8), high(uint8), 0'u8, 128)
+    chkInplaceSubstraction(chk, high(uint16) - 17'u16, 17'u16, high(uint16) - 34'u16, 128)
+    chkInplaceSubstraction(chk, high(uint16), high(uint16), 0'u16, 128)
+    chkInplaceSubstraction(chk, high(uint32) - 17'u32, 17'u32, high(uint32) - 34'u32, 128)
+    chkInplaceSubstraction(chk, high(uint32), high(uint32), 0'u32, 128)
+    when (NimMajor, NimMinor, NimPatch) >= (1, 0, 0):
+      chkInplaceSubstraction(chk, high(uint64) - 17'u64, 17'u64, high(uint64) - 34'u64, 128)
+      chkInplaceSubstraction(chk, high(uint64), high(uint64), 0'u64, 128)
+
+static:
+  testAddSub(doAssert, ctTest)
+
+suite "Wider unsigned int coverage":
+  testAddSub(check, test)
+
 suite "Testing unsigned int addition implementation":
   test "In-place addition gives expected result":
 

--- a/tests/test_uint_bitops2.nim
+++ b/tests/test_uint_bitops2.nim
@@ -9,24 +9,216 @@
 
 import ../stint, unittest
 
+template chkCountOnes(chk: untyped, bits: int) =
+  block:
+    var x = 0.stuint(bits)
+    chk x.countOnes == 0
+
+    for i in 1 .. bits:
+      x = x shl 1
+      x = x or 1.stuint(bits)
+      chk x.countOnes == i
+
+template chkParity(chk: untyped, bits: int) =
+  block:
+    var x = 0.stuint(bits)
+    chk x.parity == 0
+
+    for i in 1 .. bits:
+      x = x shl 1
+      x = x or 1.stuint(bits)
+      chk x.parity == (i mod 2)
+
+template chkFirstOne(chk: untyped, bits: int) =
+  block:
+    var x = 0.stuint(bits)
+    chk x.firstOne == 0
+    x = x + 1
+    chk x.firstOne == 1
+
+    for i in 2 .. bits:
+      x = x shl 1
+      chk x.firstOne == i
+
+template chkLeadingZeros(chk: untyped, bits: int) =
+  block:
+    var x = 0.stuint(bits)
+    chk x.leadingZeros == bits
+    x = x + 1
+    chk x.leadingZeros == (bits-1)
+
+    for i in 2 .. bits:
+      x = x shl 1
+      chk x.leadingZeros == (bits-i)
+
+template chkTrailingZeros(chk: untyped, bits: int) =
+  block:
+    var x = 0.stuint(bits)
+    chk x.trailingZeros == bits
+    x = x + 1
+    chk x.trailingZeros == 0
+
+    for i in 1 .. bits:
+      x = x shl 1
+      chk x.trailingZeros == i
+
+template ctTest(name: string, body: untyped) =
+  body
+  echo "[OK] compile time ", name
+
+template testBitOps(chk, tst: untyped) =
+  tst "countOnes":
+    chk countOnes(0b01000100'u8.stuint(8)) == 2
+
+    chk countOnes(0b01000100'u8.stuint(16)) == 2
+    chk countOnes(0b01000100_01000100'u16.stuint(16)) == 4
+
+    chk countOnes(0b01000100'u8.stuint(32)) == 2
+    chk countOnes(0b01000100_01000100'u16.stuint(32)) == 4
+    chk countOnes(0b01000100_01000100_01000100_01000100'u32.stuint(32)) == 8
+
+    chk countOnes(0b01000100'u8.stuint(64)) == 2
+    chk countOnes(0b01000100_01000100'u16.stuint(64)) == 4
+    chk countOnes(0b01000100_01000100_01000100_01000100'u32.stuint(64)) == 8
+    chk countOnes(0b01000100_01000100_01000100_01000100_01000100_01000100_01000100_01000100'u64.stuint(64)) == 16
+
+    chk countOnes(0b01000100'u8.stuint(128)) == 2
+    chk countOnes(0b01000100_01000100'u16.stuint(128)) == 4
+    chk countOnes(0b01000100_01000100_01000100_01000100'u32.stuint(128)) == 8
+    chk countOnes(0b01000100_01000100_01000100_01000100_01000100_01000100_01000100_01000100'u64.stuint(128)) == 16
+    chk countOnes(0b01000100'u8.stuint(128) shl 100) == 2
+
+    chkCountOnes(chk, 128)
+    chkCountOnes(chk, 256)
+
+  tst "parity":
+    chk parity(0b00000001'u8.stuint(8)) == 1
+    chk parity(0b00000011'u8.stuint(8)) == 0
+
+    chk parity(0b00000001'u8.stuint(16)) == 1
+    chk parity(0b00000011'u8.stuint(16)) == 0
+    chk parity(0b00000001_00000001'u16.stuint(16)) == 0
+    chk parity(0b00000011_00000001'u16.stuint(16)) == 1
+
+    chk parity(0b00000001'u8.stuint(32)) == 1
+    chk parity(0b00000011'u8.stuint(32)) == 0
+    chk parity(0b00000001_00000001'u16.stuint(32)) == 0
+    chk parity(0b00000011_00000001'u16.stuint(32)) == 1
+    chk parity(0b00000001_00000001_00000001_00000001'u32.stuint(32)) == 0
+    chk parity(0b00000011_00000001_00000001_00000001'u32.stuint(32)) == 1
+
+    chk parity(0b00000001'u8.stuint(64)) == 1
+    chk parity(0b00000011'u8.stuint(64)) == 0
+    chk parity(0b00000001_00000001'u16.stuint(64)) == 0
+    chk parity(0b00000011_00000001'u16.stuint(64)) == 1
+    chk parity(0b00000001_00000001_00000001_00000001'u32.stuint(64)) == 0
+    chk parity(0b00000011_00000001_00000001_00000001'u32.stuint(64)) == 1
+    chk parity(0b00000001_00000001_00000001_00000001_00000001_00000001_00000001_00000001'u64.stuint(64)) == 0
+    chk parity(0b00000011_00000001_00000001_00000001_00000001_00000001_00000001_00000001'u64.stuint(64)) == 1
+
+    chk parity(0b00000001'u8.stuint(128)) == 1
+    chk parity(0b00000011'u8.stuint(128)) == 0
+    chk parity(0b00000001_00000001'u16.stuint(128)) == 0
+    chk parity(0b00000011_00000001'u16.stuint(128)) == 1
+    chk parity(0b00000001_00000001_00000001_00000001'u32.stuint(128)) == 0
+    chk parity(0b00000011_00000001_00000001_00000001'u32.stuint(128)) == 1
+    chk parity(0b00000001_00000001_00000001_00000001_00000001_00000001_00000001_00000001'u64.stuint(128)) == 0
+    chk parity(0b00000011_00000001_00000001_00000001_00000001_00000001_00000001_00000001'u64.stuint(128)) == 1
+
+    chk parity(0b00000001'u8.stuint(128)) == 1
+    chk parity(0b00000001'u8.stuint(128) shl 100) == 1
+
+    chkParity(chk, 128)
+    chkParity(chk, 256)
+
+  tst "firstOne":
+    chk firstOne(0b00000010'u8.stuint(8)) == 2
+
+    chk firstOne(0b00000010'u8.stuint(16)) == 2
+    chk firstOne(0b00000010_00000000'u16.stuint(16)) == 10
+
+    chk firstOne(0b00000010'u8.stuint(32)) == 2
+    chk firstOne(0b00000010_00000000'u16.stuint(32)) == 10
+    chk firstOne(0b00000010_00000000_00000000_00000000'u32.stuint(32)) == 26
+
+    chk firstOne(0b00000010'u8.stuint(64)) == 8*0+2
+    chk firstOne(0b00000010_00000000'u16.stuint(64)) == 8*1+2
+    chk firstOne(0b00000010_00000000_00000000_00000000'u32.stuint(64)) == 8*3+2
+    chk firstOne(0b00000010_00000000_00000000_00000000_00000000_00000000_00000000_00000000'u64.stuint(64)) == 8*7+2
+
+    chk firstOne(0b00000010'u8.stuint(128)) == 2
+    chk firstOne(0b00000010'u8.stuint(128) shl 100) == 102
+    chk firstOne(0'u8.stuint(128)) == 0
+
+    chkFirstOne(chk, 128)
+    chkFirstOne(chk, 256)
+
+  tst "leadingZeros":
+    chk leadingZeros(0'u8.stuint(8)) == 8*1
+    chk leadingZeros(0b00010000'u8.stuint(8)) == 3
+
+    chk leadingZeros(0'u8.stuint(16)) == 8*2
+    chk leadingZeros(0b00010000'u8.stuint(16)) == 8*1+3
+    chk leadingZeros(0'u16.stuint(16)) == 8*2
+    chk leadingZeros(0b00000000_00010000'u16.stuint(16)) == 8*1+3
+
+    chk leadingZeros(0'u8.stuint(32)) == 8*4
+    chk leadingZeros(0b00010000'u8.stuint(32)) == 8*3+3
+    chk leadingZeros(0'u16.stuint(32)) == 8*4
+    chk leadingZeros(0b00000000_00010000'u16.stuint(32)) == 8*3+3
+    chk leadingZeros(0'u32.stuint(32)) == 8*4
+    chk leadingZeros(0b00000000_00000000_00000000_00010000'u32.stuint(32)) == 8*3+3
+
+    chk leadingZeros(0'u8.stuint(64)) == 8*8
+    chk leadingZeros(0b00010000'u8.stuint(64)) == 8*7+3
+    chk leadingZeros(0'u16.stuint(64)) == 8*8
+    chk leadingZeros(0b00000000_00010000'u16.stuint(64)) == 8*7+3
+    chk leadingZeros(0'u32.stuint(64)) == 8*8
+    chk leadingZeros(0b00000000_00000000_00000000_00010000'u32.stuint(64)) == 8*7+3
+    chk leadingZeros(0'u64.stuint(64)) == 8*8
+    chk leadingZeros(0b00000000_00000000_00000000_00000000_00000000_00000000_00000000_00010000'u64.stuint(64)) == 8*7+3
+
+    chk leadingZeros(0'u8.stuint(128)) == 128
+    chk leadingZeros(0b00100000'u8.stuint(128)) == 128 - 6
+    chk leadingZeros(0b00100000'u8.stuint(128) shl 100) == 128 - 106
+
+    chkLeadingZeros(chk, 128)
+    chkLeadingZeros(chk, 256)
+
+  tst "trailingZeros":
+    chk trailingZeros(0'u8.stuint(8)) == 8*1
+    chk trailingZeros(0b00010000'u8.stuint(8)) == 4
+
+    chk trailingZeros(0'u8.stuint(16)) == 8*2
+    chk trailingZeros(0b00010000'u8.stuint(16)) == 8*0+4
+    chk trailingZeros(0'u16.stuint(16)) == 8*2
+    chk trailingZeros(0b00010000_00000000'u16.stuint(16)) == 8*1+4
+
+    chk trailingZeros(0'u8.stuint(32)) == 8*4
+    chk trailingZeros(0b00010000'u8.stuint(32)) == 8*0+4
+    chk trailingZeros(0'u16.stuint(32)) == 8*4
+    chk trailingZeros(0b00010000_00000000'u16.stuint(32)) == 8*1+4
+    chk trailingZeros(0'u32.stuint(32)) == 8*4
+    chk trailingZeros(0b00010000_00000000_00000000_00000000'u32.stuint(32)) == 8*3+4
+
+    chk trailingZeros(0'u8.stuint(64)) == 8*8
+    chk trailingZeros(0b00010000'u8.stuint(64)) == 8*0+4
+    chk trailingZeros(0'u16.stuint(64)) == 8*8
+    chk trailingZeros(0b00010000_00000000'u16.stuint(64)) == 8*1+4
+    chk trailingZeros(0'u32.stuint(64)) == 8*8
+    chk trailingZeros(0b00010000_00000000_00000000_00000000'u32.stuint(64)) == 8*3+4
+    chk trailingZeros(0'u64.stuint(64)) == 8*8
+    chk trailingZeros(0b00010000_00000000_00000000_00000000_00000000_00000000_00000000_00000000'u64.stuint(64)) == 8*7+4
+
+    chk trailingZeros(0b00100000'u8.stuint(128)) == 5
+    chk trailingZeros(0b00100000'u8.stuint(128) shl 100) == 105
+    chk trailingZeros(0'u8.stuint(128)) == 128
+
+    chkTrailingZeros(chk, 128)
+    chkTrailingZeros(chk, 256)
+
+static:
+  testBitOps(doAssert, ctTest)
+
 suite "Testing bitops2":
-  test "Bitops give sane results":
-
-    check:
-      countOnes(0b01000100'u8.stuint(128)) == 2
-      countOnes(0b01000100'u8.stuint(128) shl 100) == 2
-
-      parity(0b00000001'u8.stuint(128)) == 1
-      parity(0b00000001'u8.stuint(128) shl 100) == 1
-
-      firstOne(0b00000010'u8.stuint(128)) == 2
-      firstOne(0b00000010'u8.stuint(128) shl 100) == 102
-      firstOne(0'u8.stuint(128)) == 0
-
-      leadingZeros(0'u8.stuint(128)) == 128
-      leadingZeros(0b00100000'u8.stuint(128)) == 128 - 6
-      leadingZeros(0b00100000'u8.stuint(128) shl 100) == 128 - 106
-
-      trailingZeros(0b00100000'u8.stuint(128)) == 5
-      trailingZeros(0b00100000'u8.stuint(128) shl 100) == 105
-      trailingZeros(0'u8.stuint(128)) == 128
+  testBitOps(check, test)

--- a/tests/test_uint_bitops2.nim
+++ b/tests/test_uint_bitops2.nim
@@ -7,7 +7,7 @@
 #
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import ../stint, unittest
+import ../stint, unittest, test_helpers
 
 template chkCountOnes(chk: untyped, bits: int) =
   block:
@@ -61,10 +61,6 @@ template chkTrailingZeros(chk: untyped, bits: int) =
     for i in 1 .. bits:
       x = x shl 1
       chk x.trailingZeros == i
-
-template ctTest(name: string, body: untyped) =
-  body
-  echo "[OK] compile time ", name
 
 template testBitOps(chk, tst: untyped) =
   tst "countOnes":
@@ -218,7 +214,7 @@ template testBitOps(chk, tst: untyped) =
     chkTrailingZeros(chk, 256)
 
 static:
-  testBitOps(doAssert, ctTest)
+  testBitOps(ctCheck, ctTest)
 
 suite "Testing bitops2":
   testBitOps(check, test)

--- a/tests/test_uint_bitwise.nim
+++ b/tests/test_uint_bitwise.nim
@@ -9,6 +9,312 @@
 
 import ../stint, unittest
 
+template chkNot(chk: untyped, a, b: distinct SomeInteger, bits: int) =
+  chk stuint(a, bits).not() == stuint(b, bits)
+
+template chkNot(chk: untyped, a, b: string, bits: int) =
+  chk fromHex(Stuint[bits], a).not() == fromHex(Stuint[bits], b)
+
+template chkOr(chk: untyped, a, b, c: string, bits: int) =
+  chk (fromHex(Stuint[bits], a) or fromHex(Stuint[bits], b)) == fromHex(Stuint[bits], c)
+
+template chkAnd(chk: untyped, a, b, c: string, bits: int) =
+  chk (fromHex(Stuint[bits], a) and fromHex(Stuint[bits], b)) == fromHex(Stuint[bits], c)
+
+template chkXor(chk: untyped, a, b, c: string, bits: int) =
+  chk (fromHex(Stuint[bits], a) xor fromHex(Stuint[bits], b)) == fromHex(Stuint[bits], c)
+
+template chkShl(chk: untyped, a: string, b: SomeInteger, c: string, bits: int) =
+  chk (fromHex(Stuint[bits], a) shl b) == fromHex(Stuint[bits], c)
+
+template chkShr(chk: untyped, a: string, b: SomeInteger, c: string, bits: int) =
+  chk (fromHex(Stuint[bits], a) shr b) == fromHex(Stuint[bits], c)
+
+template ctTest(name: string, body: untyped) =
+  body
+  echo "[OK] compile time ", name
+
+template testBitwise(chk, tst: untyped) =
+
+  # TODO: see issue #95
+  #chkShl(chk, "0F", 8, "00", 8)
+  #chkShl(chk, "0F", 16, "00", 16)
+  #chkShl(chk, "0F", 32, "00", 32)
+  #chkShl(chk, "0F", 64, "00", 64)
+  #chkShl(chk, "0F", 128, "00", 128)
+  #chkShl(chk, "0F", 256, "00", 256)
+  #
+  #chkShr(chk, "F0", 8, "00", 8)
+  #chkShr(chk, "F000", 16, "00", 16)
+  #chkShr(chk, "F0000000", 32, "00", 32)
+  #chkShr(chk, "F000000000000000", 64, "00", 64)
+  #chkShr(chk, "F0000000000000000000000000000000", 128, "00", 128)
+
+  tst "operator `not`":
+    chkNot(chk, 0'u8, not 0'u8, 8)
+    chkNot(chk, high(uint8), not high(uint8), 8)
+    chkNot(chk, "F0", "0F", 8)
+    chkNot(chk, "0F", "F0", 8)
+
+    chkNot(chk, 0'u8, not 0'u16, 16)
+    chkNot(chk, 0'u16, not 0'u16, 16)
+    chkNot(chk, high(uint8), not uint16(high(uint8)), 16)
+    chkNot(chk, high(uint16), not high(uint16), 16)
+    chkNot(chk, "F0", "FF0F", 16)
+    chkNot(chk, "0F", "FFF0", 16)
+    chkNot(chk, "FF00", "00FF", 16)
+    chkNot(chk, "00FF", "FF00", 16)
+    chkNot(chk, "0FF0", "F00F", 16)
+
+    chkNot(chk, 0'u8, not 0'u32, 32)
+    chkNot(chk, 0'u16, not 0'u32, 32)
+    chkNot(chk, 0'u32, not 0'u32, 32)
+    chkNot(chk, high(uint8), not uint32(high(uint8)), 32)
+    chkNot(chk, high(uint16), not uint32(high(uint16)), 32)
+    chkNot(chk, high(uint32), not high(uint32), 32)
+    chkNot(chk, "F0", "FFFFFF0F", 32)
+    chkNot(chk, "0F", "FFFFFFF0", 32)
+    chkNot(chk, "FF00", "FFFF00FF", 32)
+    chkNot(chk, "00FF", "FFFFFF00", 32)
+    chkNot(chk, "0000FFFF", "FFFF0000", 32)
+    chkNot(chk, "00FFFF00", "FF0000FF", 32)
+    chkNot(chk, "0F0F0F0F", "F0F0F0F0", 32)
+
+    chkNot(chk, 0'u8, not 0'u64, 64)
+    chkNot(chk, 0'u16, not 0'u64, 64)
+    chkNot(chk, 0'u32, not 0'u64, 64)
+    chkNot(chk, 0'u64, not 0'u64, 64)
+    chkNot(chk, high(uint8), not uint64(high(uint8)), 64)
+    chkNot(chk, high(uint16), not uint64(high(uint16)), 64)
+    chkNot(chk, high(uint32), not uint64(high(uint32)), 64)
+    chkNot(chk, high(uint64), not high(uint64), 64)
+
+    chkNot(chk, "0", "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", 128)
+    chkNot(chk, "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "0", 128)
+    chkNot(chk, "F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0", "0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F", 128)
+    chkNot(chk, "FFFFFFFFFFFF00000000000000000000", "000000000000FFFFFFFFFFFFFFFFFFFF", 128)
+
+  tst "operator `or`":
+    chkOr(chk, "00", "FF", "FF", 8)
+    chkOr(chk, "FF", "00", "FF", 8)
+    chkOr(chk, "F0", "0F", "FF", 8)
+    chkOr(chk, "00", "00", "00", 8)
+
+    chkOr(chk, "00", "FF", "00FF", 16)
+    chkOr(chk, "FF", "00", "00FF", 16)
+    chkOr(chk, "F0", "0F", "00FF", 16)
+    chkOr(chk, "00", "00", "0000", 16)
+    chkOr(chk, "FF00", "0F00", "FF00", 16)
+
+    chkOr(chk, "00", "FF", "000000FF", 32)
+    chkOr(chk, "FF", "00", "000000FF", 32)
+    chkOr(chk, "F0", "0F", "000000FF", 32)
+    chkOr(chk, "00", "00", "00000000", 32)
+    chkOr(chk, "FF00", "0F00", "0000FF00", 32)
+    chkOr(chk, "00FF00FF", "000F000F", "00FF00FF", 32)
+
+    chkOr(chk, "00", "FF", "00000000000000FF", 64)
+    chkOr(chk, "FF", "00", "00000000000000FF", 64)
+    chkOr(chk, "F0", "0F", "00000000000000FF", 64)
+    chkOr(chk, "00", "00", "0000000000000000", 64)
+    chkOr(chk, "FF00", "0F00", "000000000000FF00", 64)
+    chkOr(chk, "00FF00FF", "000F000F", "0000000000FF00FF", 64)
+
+    chkOr(chk, "00", "FF", "000000000000000000000000000000FF", 128)
+    chkOr(chk, "FF", "00", "000000000000000000000000000000FF", 128)
+    chkOr(chk, "F0", "0F", "000000000000000000000000000000FF", 128)
+    chkOr(chk, "00", "00", "00000000000000000000000000000000", 128)
+    chkOr(chk, "FF00", "0F00", "0000000000000000000000000000FF00", 128)
+    chkOr(chk, "00FF00FF", "000F000F", "00000000000000000000000000FF00FF", 128)
+    chkOr(chk, "00000000000000000000000000FF00FF", "FF0F0000000000000000000000FF00FF", "FF0F0000000000000000000000FF00FF", 128)
+
+  tst "operator `and`":
+    chkAnd(chk, "00", "FF", "00", 8)
+    chkAnd(chk, "FF", "00", "00", 8)
+    chkAnd(chk, "F0", "0F", "00", 8)
+    chkAnd(chk, "00", "00", "00", 8)
+    chkAnd(chk, "0F", "0F", "0F", 8)
+    chkAnd(chk, "FF", "FF", "FF", 8)
+
+    chkAnd(chk, "00", "FF", "0000", 16)
+    chkAnd(chk, "FF", "00", "0000", 16)
+    chkAnd(chk, "F0", "0F", "0000", 16)
+    chkAnd(chk, "00", "00", "0000", 16)
+    chkAnd(chk, "FF00", "0F00", "0F00", 16)
+
+    chkAnd(chk, "00", "FF", "00000000", 32)
+    chkAnd(chk, "FF", "00", "00000000", 32)
+    chkAnd(chk, "F0", "0F", "00000000", 32)
+    chkAnd(chk, "00", "00", "00000000", 32)
+    chkAnd(chk, "FF00", "0F00", "00000F00", 32)
+    chkAnd(chk, "00FF00FF", "000F000F", "000F000F", 32)
+
+    chkAnd(chk, "00", "FF", "0000000000000000", 64)
+    chkAnd(chk, "FF", "00", "0000000000000000", 64)
+    chkAnd(chk, "F0", "0F", "0000000000000000", 64)
+    chkAnd(chk, "00", "00", "0000000000000000", 64)
+    chkAnd(chk, "FF00", "0F00", "0000000000000F00", 64)
+    chkAnd(chk, "00FF00FF", "000F000F", "00000000000F000F", 64)
+
+    chkAnd(chk, "00", "FF", "00000000000000000000000000000000", 128)
+    chkAnd(chk, "FF", "00", "00000000000000000000000000000000", 128)
+    chkAnd(chk, "F0", "0F", "00000000000000000000000000000000", 128)
+    chkAnd(chk, "00", "00", "00000000000000000000000000000000", 128)
+    chkAnd(chk, "FF00", "0F00", "00000000000000000000000000000F00", 128)
+    chkAnd(chk, "00FF00FF", "000F000F", "000000000000000000000000000F000F", 128)
+    chkAnd(chk, "F0000000000000000000000000FF00FF", "FF0F0000000000000000000000FF00FF", "F0000000000000000000000000FF00FF", 128)
+
+  tst "operator `xor`":
+    chkXor(chk, "00", "FF", "FF", 8)
+    chkXor(chk, "FF", "00", "FF", 8)
+    chkXor(chk, "F0", "0F", "FF", 8)
+    chkXor(chk, "00", "00", "00", 8)
+    chkXor(chk, "0F", "0F", "00", 8)
+    chkXor(chk, "FF", "FF", "00", 8)
+
+    chkXor(chk, "00", "FF", "00FF", 16)
+    chkXor(chk, "FF", "00", "00FF", 16)
+    chkXor(chk, "F0", "0F", "00FF", 16)
+    chkXor(chk, "00", "00", "0000", 16)
+    chkXor(chk, "FF00", "0F00", "F000", 16)
+
+    chkXor(chk, "00", "FF", "000000FF", 32)
+    chkXor(chk, "FF", "00", "000000FF", 32)
+    chkXor(chk, "F0", "0F", "000000FF", 32)
+    chkXor(chk, "00", "00", "00000000", 32)
+    chkXor(chk, "FF00", "0F00", "0000F000", 32)
+    chkXor(chk, "00FF00FF", "000F000F", "00F000F0", 32)
+
+    chkXor(chk, "00", "FF", "00000000000000FF", 64)
+    chkXor(chk, "FF", "00", "00000000000000FF", 64)
+    chkXor(chk, "F0", "0F", "00000000000000FF", 64)
+    chkXor(chk, "00", "00", "0000000000000000", 64)
+    chkXor(chk, "FF00", "0F00", "000000000000F000", 64)
+    chkXor(chk, "00FF00FF", "000F000F", "0000000000F000F0", 64)
+
+    chkXor(chk, "00", "FF", "000000000000000000000000000000FF", 128)
+    chkXor(chk, "FF", "00", "000000000000000000000000000000FF", 128)
+    chkXor(chk, "F0", "0F", "000000000000000000000000000000FF", 128)
+    chkXor(chk, "00", "00", "00000000000000000000000000000000", 128)
+    chkXor(chk, "FF00", "0F00", "0000000000000000000000000000F000", 128)
+    chkXor(chk, "00FF00FF", "000F000F", "00000000000000000000000000F000F0", 128)
+    chkXor(chk, "F0000000000000000000000000FF00FF", "FF0F0000000000000000000000FF00FF", "0F0F0000000000000000000000000000", 128)
+
+  tst "operator `shl`":
+    chkShl(chk, "0F", 4, "F0", 8)
+    chkShl(chk, "F0", 4, "00", 8)
+    chkShl(chk, "F0", 3, "80", 8)
+    chkShl(chk, "0F", 7, "80", 8)
+
+    chkShl(chk, "0F", 4, "F0", 16)
+    chkShl(chk, "F0", 4, "F00", 16)
+    chkShl(chk, "F0", 3, "780", 16)
+    chkShl(chk, "F000", 3, "8000", 16)
+    chkShl(chk, "0F", 15, "8000", 16)
+
+    chkShl(chk, "0F", 4, "F0", 32)
+    chkShl(chk, "F0", 4, "F00", 32)
+    chkShl(chk, "F0", 3, "780", 32)
+    chkShl(chk, "F000", 3, "78000", 32)
+    chkShl(chk, "F0000000", 3, "80000000", 32)
+    chkShl(chk, "0F", 31, "80000000", 32)
+
+    chkShl(chk, "0F", 4, "F0", 64)
+    chkShl(chk, "F0", 4, "F00", 64)
+    chkShl(chk, "F0", 3, "780", 64)
+    chkShl(chk, "F000", 3, "78000", 64)
+    chkShl(chk, "F0000000", 3, "780000000", 64)
+    chkShl(chk, "F000000000000000", 3, "8000000000000000", 64)
+    chkShl(chk, "0F", 63, "8000000000000000", 64)
+
+    chkShl(chk, "0F", 5, "1E0", 64)
+    chkShl(chk, "0F", 9, "1E00", 64)
+    chkShl(chk, "0F", 17, "1E0000", 64)
+    chkShl(chk, "0F", 33, "1E00000000", 64)
+
+    chkShl(chk, "0F", 4, "F0", 128)
+    chkShl(chk, "F0", 4, "F00", 128)
+    chkShl(chk, "F0", 3, "780", 128)
+    chkShl(chk, "F000", 3, "78000", 128)
+    chkShl(chk, "F0000000", 3, "780000000", 128)
+    chkShl(chk, "F000000000000000", 3, "78000000000000000", 128)
+    chkShl(chk, "F0000000000000000000000000000000", 3, "80000000000000000000000000000000", 128)
+
+    chkShl(chk, "0F", 33, "1E00000000", 128)
+    chkShl(chk, "0F", 65, "1E0000000000000000", 128)
+    chkShl(chk, "0F", 97, "1E000000000000000000000000", 128)
+    chkShl(chk, "0F", 127, "80000000000000000000000000000000", 128)
+
+    chkShl(chk, "0F", 4, "F0", 256)
+    chkShl(chk, "F0", 4, "F00", 256)
+    chkShl(chk, "F0", 3, "780", 256)
+    chkShl(chk, "F000", 3, "78000", 256)
+    chkShl(chk, "F0000000", 3, "780000000", 256)
+    chkShl(chk, "F000000000000000", 3, "78000000000000000", 256)
+    chkShl(chk, "F0000000000000000000000000000000", 3, "780000000000000000000000000000000", 256)
+
+    chkShl(chk, "0F", 33, "1E00000000", 256)
+    chkShl(chk, "0F", 65, "1E0000000000000000", 256)
+    chkShl(chk, "0F", 97, "1E000000000000000000000000", 256)
+    chkShl(chk, "0F", 128, "0F00000000000000000000000000000000", 256)
+    chkShl(chk, "0F", 129, "1E00000000000000000000000000000000", 256)
+    chkShl(chk, "0F", 255, "8000000000000000000000000000000000000000000000000000000000000000", 256)
+
+  tst "operator `shr`":
+    chkShr(chk, "0F", 4, "00", 8)
+    chkShr(chk, "F0", 4, "0F", 8)
+    chkShr(chk, "F0", 3, "1E", 8)
+    chkShr(chk, "F0", 7, "01", 8)
+
+    chkShr(chk, "0F", 4, "00", 16)
+    chkShr(chk, "F0", 4, "0F", 16)
+    chkShr(chk, "F000", 3, "1E00", 16)
+    chkShr(chk, "F000", 15, "0001", 16)
+
+    chkShr(chk, "0F", 4, "00", 32)
+    chkShr(chk, "F0", 4, "0F", 32)
+    chkShr(chk, "F0", 3, "1E", 32)
+    chkShr(chk, "F0000000", 3, "1E000000", 32)
+    chkShr(chk, "F0000000", 31, "00000001", 32)
+
+    chkShr(chk, "0F", 4, "00", 64)
+    chkShr(chk, "F0", 4, "0F", 64)
+    chkShr(chk, "F0", 3, "1E", 64)
+    chkShr(chk, "F000", 3, "1E00", 64)
+    chkShr(chk, "F0000000", 3, "1E000000", 64)
+    chkShr(chk, "F000000000000000", 63, "0000000000000001", 64)
+
+    chkShr(chk, "0F", 4, "00", 128)
+    chkShr(chk, "F0", 4, "0F", 128)
+    chkShr(chk, "F0", 3, "1E", 128)
+    chkShr(chk, "F000", 3, "1E00", 128)
+    chkShr(chk, "F0000000", 3, "1E000000", 128)
+    chkShr(chk, "F000000000000000", 3, "1E00000000000000", 128)
+    chkShr(chk, "F0000000000000000000000000000000", 127, "00000000000000000000000000000001", 128)
+
+    chkShr(chk, "F0000000000000000000000000000000", 33, "00000000780000000000000000000000", 128)
+    chkShr(chk, "F0000000000000000000000000000000", 65, "00000000000000007800000000000000", 128)
+    chkShr(chk, "F0000000000000000000000000000000", 97, "00000000000000000000000078000000", 128)
+
+    chkShr(chk, "0F", 4, "00", 256)
+    chkShr(chk, "F0", 4, "0F", 256)
+    chkShr(chk, "F0", 3, "1E", 256)
+    chkShr(chk, "F000", 3, "1E00", 256)
+    chkShr(chk, "F0000000", 3, "1E000000", 256)
+    chkShr(chk, "F000000000000000", 3, "1E00000000000000", 256)
+    chkShr(chk, "F000000000000000000000000000000000000000000000000000000000000000", 255, "1", 256)
+
+    chkShr(chk, "F000000000000000000000000000000000000000000000000000000000000000", 33, "0000000078000000000000000000000000000000000000000000000000000000", 256)
+    chkShr(chk, "F000000000000000000000000000000000000000000000000000000000000000", 65, "0000000000000000780000000000000000000000000000000000000000000000", 256)
+    chkShr(chk, "F000000000000000000000000000000000000000000000000000000000000000", 129, "0000000000000000000000000000000078000000000000000000000000000000", 256)
+    chkShr(chk, "F000000000000000000000000000000000000000000000000000000000000000", 233, "780000", 256)
+
+static:
+  testBitwise(doAssert, ctTest)
+
+suite "Wider unsigned int bitwise coverage":
+  testBitwise(check, test)
+
 suite "Testing unsigned int bitwise operations":
   let a = 100'i16.stuint(16)
 

--- a/tests/test_uint_bitwise.nim
+++ b/tests/test_uint_bitwise.nim
@@ -7,7 +7,7 @@
 #
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import ../stint, unittest
+import ../stint, unittest, test_helpers
 
 template chkNot(chk: untyped, a, b: distinct SomeInteger, bits: int) =
   chk stuint(a, bits).not() == stuint(b, bits)
@@ -29,10 +29,6 @@ template chkShl(chk: untyped, a: string, b: SomeInteger, c: string, bits: int) =
 
 template chkShr(chk: untyped, a: string, b: SomeInteger, c: string, bits: int) =
   chk (fromHex(Stuint[bits], a) shr b) == fromHex(Stuint[bits], c)
-
-template ctTest(name: string, body: untyped) =
-  body
-  echo "[OK] compile time ", name
 
 template testBitwise(chk, tst: untyped) =
 
@@ -311,7 +307,7 @@ template testBitwise(chk, tst: untyped) =
     chkShr(chk, "F000000000000000000000000000000000000000000000000000000000000000", 233, "780000", 256)
 
 static:
-  testBitwise(doAssert, ctTest)
+  testBitwise(ctCheck, ctTest)
 
 suite "Wider unsigned int bitwise coverage":
   testBitwise(check, test)

--- a/tests/test_uint_bitwise.nim
+++ b/tests/test_uint_bitwise.nim
@@ -87,7 +87,8 @@ template testBitwise(chk, tst: untyped) =
     chkNot(chk, high(uint8), not uint64(high(uint8)), 64)
     chkNot(chk, high(uint16), not uint64(high(uint16)), 64)
     chkNot(chk, high(uint32), not uint64(high(uint32)), 64)
-    chkNot(chk, high(uint64), not high(uint64), 64)
+    when (NimMajor, NimMinor, NimPatch) >= (1, 0, 0):
+      chkNot(chk, high(uint64), not high(uint64), 64)
 
     chkNot(chk, "0", "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", 128)
     chkNot(chk, "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "0", 128)

--- a/tests/test_uint_comparison.nim
+++ b/tests/test_uint_comparison.nim
@@ -13,25 +13,25 @@ template chkLT(chk: untyped, a, b: string, bits: int) =
   chk fromHex(Stuint[bits], a) < fromHex(Stuint[bits], b)
 
 template chknotLT(chk: untyped, a, b: string, bits: int) =
-  chk not(fromHex(Stuint[bits], b) < fromHex(Stuint[bits], a))
+  chk (not(fromHex(Stuint[bits], b) < fromHex(Stuint[bits], a)))
 
 template chkLTE(chk: untyped, a, b: string, bits: int) =
   chk fromHex(Stuint[bits], a) <= fromHex(Stuint[bits], b)
 
 template chknotLTE(chk: untyped, a, b: string, bits: int) =
-  chk not(fromHex(Stuint[bits], b) <= fromHex(Stuint[bits], a))
+  chk (not(fromHex(Stuint[bits], b) <= fromHex(Stuint[bits], a)))
 
 template chkEQ(chk: untyped, a, b: string, bits: int) =
   chk fromHex(Stuint[bits], a) == fromHex(Stuint[bits], b)
 
 template chknotEQ(chk: untyped, a, b: string, bits: int) =
-  chk not(fromHex(Stuint[bits], a) == fromHex(Stuint[bits], b))
+  chk (not(fromHex(Stuint[bits], a) == fromHex(Stuint[bits], b)))
 
 template chkisZero(chk: untyped, a: string, bits: int) =
   chk fromHex(Stuint[bits], a).isZero()
 
 template chknotisZero(chk: untyped, a: string, bits: int) =
-  chk not fromHex(Stuint[bits], a).isZero()
+  chk (not fromHex(Stuint[bits], a).isZero())
 
 template chkisOdd(chk: untyped, a: string, bits: int) =
   chk fromHex(Stuint[bits], a).isOdd()
@@ -43,7 +43,7 @@ template chkisEven(chk: untyped, a: string, bits: int) =
   chk fromHex(Stuint[bits], a).isEven()
 
 template chknotisEven(chk: untyped, a: string, bits: int) =
-  chk not fromHex(Stuint[bits], a).isEven()
+  chk (not fromHex(Stuint[bits], a).isEven())
 
 template ctTest(name: string, body: untyped) =
   body

--- a/tests/test_uint_comparison.nim
+++ b/tests/test_uint_comparison.nim
@@ -7,7 +7,7 @@
 #
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import ../stint, unittest
+import ../stint, unittest, test_helpers
 
 template chkLT(chk: untyped, a, b: string, bits: int) =
   chk fromHex(Stuint[bits], a) < fromHex(Stuint[bits], b)
@@ -44,10 +44,6 @@ template chkisEven(chk: untyped, a: string, bits: int) =
 
 template chknotisEven(chk: untyped, a: string, bits: int) =
   chk (not fromHex(Stuint[bits], a).isEven())
-
-template ctTest(name: string, body: untyped) =
-  body
-  echo "[OK] compile time ", name
 
 template testComparison(chk, tst: untyped) =
   tst "operator `LT`":
@@ -306,7 +302,7 @@ template testComparison(chk, tst: untyped) =
     chkIsOdd(chk, "FFFFFFFFFFFFFFFFFF", 256)
 
 static:
-  testComparison(doAssert, ctTest)
+  testComparison(ctCheck, ctTest)
 
 suite "Wider unsigned int comparison coverage":
   testComparison(check, test)

--- a/tests/test_uint_comparison.nim
+++ b/tests/test_uint_comparison.nim
@@ -9,6 +9,308 @@
 
 import ../stint, unittest
 
+template chkLT(chk: untyped, a, b: string, bits: int) =
+  chk fromHex(Stuint[bits], a) < fromHex(Stuint[bits], b)
+
+template chknotLT(chk: untyped, a, b: string, bits: int) =
+  chk not(fromHex(Stuint[bits], b) < fromHex(Stuint[bits], a))
+
+template chkLTE(chk: untyped, a, b: string, bits: int) =
+  chk fromHex(Stuint[bits], a) <= fromHex(Stuint[bits], b)
+
+template chknotLTE(chk: untyped, a, b: string, bits: int) =
+  chk not(fromHex(Stuint[bits], b) <= fromHex(Stuint[bits], a))
+
+template chkEQ(chk: untyped, a, b: string, bits: int) =
+  chk fromHex(Stuint[bits], a) == fromHex(Stuint[bits], b)
+
+template chknotEQ(chk: untyped, a, b: string, bits: int) =
+  chk not(fromHex(Stuint[bits], a) == fromHex(Stuint[bits], b))
+
+template chkisZero(chk: untyped, a: string, bits: int) =
+  chk fromHex(Stuint[bits], a).isZero()
+
+template chknotisZero(chk: untyped, a: string, bits: int) =
+  chk not fromHex(Stuint[bits], a).isZero()
+
+template chkisOdd(chk: untyped, a: string, bits: int) =
+  chk fromHex(Stuint[bits], a).isOdd()
+
+template chknotisOdd(chk: untyped, a: string, bits: int) =
+  chk (not fromHex(Stuint[bits], a).isOdd())
+
+template chkisEven(chk: untyped, a: string, bits: int) =
+  chk fromHex(Stuint[bits], a).isEven()
+
+template chknotisEven(chk: untyped, a: string, bits: int) =
+  chk not fromHex(Stuint[bits], a).isEven()
+
+template ctTest(name: string, body: untyped) =
+  body
+  echo "[OK] compile time ", name
+
+template testComparison(chk, tst: untyped) =
+  tst "operator `LT`":
+    chkLT(chk, "0", "F", 8)
+    chkLT(chk, "F", "FF", 8)
+
+    chkLT(chk, "0", "F", 16)
+    chkLT(chk, "F", "FF", 16)
+    chkLT(chk, "FF", "FFF", 16)
+
+    chkLT(chk, "0", "F", 32)
+    chkLT(chk, "F", "FF", 32)
+    chkLT(chk, "FF", "FFF", 32)
+    chkLT(chk, "FFFF", "FFFFF", 32)
+
+    chkLT(chk, "0", "F", 64)
+    chkLT(chk, "F", "FF", 64)
+    chkLT(chk, "FF", "FFF", 64)
+    chkLT(chk, "FFFF", "FFFFF", 64)
+    chkLT(chk, "FFFFF", "FFFFFFFF", 64)
+
+    chkLT(chk, "0", "F", 128)
+    chkLT(chk, "F", "FF", 128)
+    chkLT(chk, "FF", "FFF", 128)
+    chkLT(chk, "FFFF", "FFFFF", 128)
+    chkLT(chk, "FFFFF", "FFFFFFFF", 128)
+    chkLT(chk, "FFFFFFFFFFF", "FFFFFFFFFFFFFFFFFFFFFFFF", 128)
+
+  tst "operator not `LT`":
+    chknotLT(chk, "0", "F", 8)
+    chknotLT(chk, "F", "FF", 8)
+
+    chknotLT(chk, "0", "F", 16)
+    chknotLT(chk, "F", "FF", 16)
+    chknotLT(chk, "FF", "FFF", 16)
+
+    chknotLT(chk, "0", "F", 32)
+    chknotLT(chk, "F", "FF", 32)
+    chknotLT(chk, "FF", "FFF", 32)
+    chknotLT(chk, "FFFF", "FFFFF", 32)
+
+    chknotLT(chk, "0", "F", 64)
+    chknotLT(chk, "F", "FF", 64)
+    chknotLT(chk, "FF", "FFF", 64)
+    chknotLT(chk, "FFFF", "FFFFF", 64)
+    chknotLT(chk, "FFFFF", "FFFFFFFF", 64)
+
+    chknotLT(chk, "0", "F", 128)
+    chknotLT(chk, "F", "FF", 128)
+    chknotLT(chk, "FF", "FFF", 128)
+    chknotLT(chk, "FFFF", "FFFFF", 128)
+    chknotLT(chk, "FFFFF", "FFFFFFFF", 128)
+    chknotLT(chk, "FFFFFFFFFFF", "FFFFFFFFFFFFFFFFFFFFFFFF", 128)
+
+  tst "operator `LTE`":
+    chkLTE(chk, "0", "F", 8)
+    chkLTE(chk, "F", "FF", 8)
+    chkLTE(chk, "F", "F", 8)
+
+    chkLTE(chk, "0", "F", 16)
+    chkLTE(chk, "F", "FF", 16)
+    chkLTE(chk, "FF", "FFF", 16)
+    chkLTE(chk, "FFF", "FFF", 16)
+
+    chkLTE(chk, "0", "F", 32)
+    chkLTE(chk, "F", "FF", 32)
+    chkLTE(chk, "FF", "FFF", 32)
+    chkLTE(chk, "FFFF", "FFFFF", 32)
+    chkLTE(chk, "FFFFF", "FFFFF", 32)
+
+    chkLTE(chk, "0", "F", 64)
+    chkLTE(chk, "F", "FF", 64)
+    chkLTE(chk, "FF", "FFF", 64)
+    chkLTE(chk, "FFFF", "FFFFF", 64)
+    chkLTE(chk, "FFFFF", "FFFFFFFF", 64)
+    chkLTE(chk, "FFFFFFFF", "FFFFFFFF", 64)
+
+    chkLTE(chk, "0", "F", 128)
+    chkLTE(chk, "F", "FF", 128)
+    chkLTE(chk, "FF", "FFF", 128)
+    chkLTE(chk, "FFFF", "FFFFF", 128)
+    chkLTE(chk, "FFFFF", "FFFFFFFF", 128)
+    chkLTE(chk, "FFFFFFFFFFF", "FFFFFFFFFFFFFFFFFFFFFFFF", 128)
+    chkLTE(chk, "FFFFFFFFFFFFFFFFFFFFFFFF", "FFFFFFFFFFFFFFFFFFFFFFFF", 128)
+
+  tst "operator not `LTE`":
+    chknotLTE(chk, "0", "F", 8)
+    chknotLTE(chk, "F", "FF", 8)
+
+    chknotLTE(chk, "0", "F", 16)
+    chknotLTE(chk, "F", "FF", 16)
+    chknotLTE(chk, "FF", "FFF", 16)
+
+    chknotLTE(chk, "0", "F", 32)
+    chknotLTE(chk, "F", "FF", 32)
+    chknotLTE(chk, "FF", "FFF", 32)
+    chknotLTE(chk, "FFFF", "FFFFF", 32)
+
+    chknotLTE(chk, "0", "F", 64)
+    chknotLTE(chk, "F", "FF", 64)
+    chknotLTE(chk, "FF", "FFF", 64)
+    chknotLTE(chk, "FFFF", "FFFFF", 64)
+    chknotLTE(chk, "FFFFF", "FFFFFFFF", 64)
+
+    chknotLTE(chk, "0", "F", 128)
+    chknotLTE(chk, "F", "FF", 128)
+    chknotLTE(chk, "FF", "FFF", 128)
+    chknotLTE(chk, "FFFF", "FFFFF", 128)
+    chknotLTE(chk, "FFFFF", "FFFFFFFF", 128)
+    chknotLTE(chk, "FFFFFFFFFFF", "FFFFFFFFFFFFFFFFFFFFFFFF", 128)
+
+  tst "operator `EQ`":
+    chkEQ(chk, "0", "0", 8)
+    chkEQ(chk, "FF", "FF", 8)
+    chkEQ(chk, "F", "F", 8)
+
+    chkEQ(chk, "0", "0", 16)
+    chkEQ(chk, "F", "F", 16)
+    chkEQ(chk, "FF", "FF", 16)
+    chkEQ(chk, "FFF", "FFF", 16)
+
+    chkEQ(chk, "0", "0", 32)
+    chkEQ(chk, "F", "F", 32)
+    chkEQ(chk, "FF", "FF", 32)
+    chkEQ(chk, "FFFF", "FFFF", 32)
+    chkEQ(chk, "FFFFF", "FFFFF", 32)
+
+    chkEQ(chk, "0", "0", 64)
+    chkEQ(chk, "F", "F", 64)
+    chkEQ(chk, "FF", "FF", 64)
+    chkEQ(chk, "FFFF", "FFFF", 64)
+    chkEQ(chk, "FFFFF", "FFFFF", 64)
+    chkEQ(chk, "FFFFFFFF", "FFFFFFFF", 64)
+
+    chkEQ(chk, "0", "0", 128)
+    chkEQ(chk, "F", "F", 128)
+    chkEQ(chk, "FF", "FF", 128)
+    chkEQ(chk, "FFFF", "FFFF", 128)
+    chkEQ(chk, "FFFFF", "FFFFF", 128)
+    chkEQ(chk, "FFFFFFFFFFFFFFFFFFFFFFFF", "FFFFFFFFFFFFFFFFFFFFFFFF", 128)
+
+  tst "operator not `EQ`":
+    chknotEQ(chk, "0", "F", 8)
+    chknotEQ(chk, "F", "FF", 8)
+
+    chknotEQ(chk, "0", "F", 16)
+    chknotEQ(chk, "F", "FF", 16)
+    chknotEQ(chk, "FF", "FFF", 16)
+
+    chknotEQ(chk, "0", "F", 32)
+    chknotEQ(chk, "F", "FF", 32)
+    chknotEQ(chk, "FF", "FFF", 32)
+    chknotEQ(chk, "FFFF", "FFFFF", 32)
+
+    chknotEQ(chk, "0", "F", 64)
+    chknotEQ(chk, "F", "FF", 64)
+    chknotEQ(chk, "FF", "FFF", 64)
+    chknotEQ(chk, "FFFF", "FFFFF", 64)
+    chknotEQ(chk, "FFFFF", "FFFFFFFF", 64)
+
+    chknotEQ(chk, "0", "F", 128)
+    chknotEQ(chk, "F", "FF", 128)
+    chknotEQ(chk, "FF", "FFF", 128)
+    chknotEQ(chk, "FFFF", "FFFFF", 128)
+    chknotEQ(chk, "FFFFF", "FFFFFFFF", 128)
+    chknotEQ(chk, "FFFFFFFFFFF", "FFFFFFFFFFFFFFFFFFFFFFFF", 128)
+
+  tst "operator `isZero`":
+    chkIsZero(chk, "0", 8)
+    chkIsZero(chk, "0", 16)
+    chkIsZero(chk, "0", 32)
+    chkIsZero(chk, "0", 64)
+    chkIsZero(chk, "0", 128)
+    chkIsZero(chk, "0", 256)
+
+  tst "operator not `isZero`":
+    chknotIsZero(chk, "1", 8)
+    chknotIsZero(chk, "2", 16)
+    chknotIsZero(chk, "3", 32)
+    chknotIsZero(chk, "4", 64)
+    chknotIsZero(chk, "5", 128)
+    chknotIsZero(chk, "6", 256)
+
+  tst "operator `isOdd`":
+    chkIsOdd(chk, "1", 8)
+    chkIsOdd(chk, "1", 16)
+    chkIsOdd(chk, "1", 32)
+    chkIsOdd(chk, "1", 64)
+    chkIsOdd(chk, "1", 128)
+    chkIsOdd(chk, "1", 256)
+
+    chkIsOdd(chk, "FF", 8)
+    chkIsOdd(chk, "FFF", 16)
+    chkIsOdd(chk, "FFFFF", 32)
+    chkIsOdd(chk, "FFFFFF", 64)
+    chkIsOdd(chk, "FFFFFFFFFFFFFFF", 128)
+    chkIsOdd(chk, "FFFFFFFFFFFFFFFFFF", 256)
+
+  tst "operator not `isOdd`":
+    chkNotIsOdd(chk, "0", 8)
+    chkNotIsOdd(chk, "0", 16)
+    chkNotIsOdd(chk, "0", 32)
+    chkNotIsOdd(chk, "0", 64)
+    chkNotIsOdd(chk, "0", 128)
+    chkNotIsOdd(chk, "0", 256)
+
+    chkNotIsOdd(chk, "4", 8)
+    chkNotIsOdd(chk, "4", 16)
+    chkNotIsOdd(chk, "4", 32)
+    chkNotIsOdd(chk, "4", 64)
+    chkNotIsOdd(chk, "4", 128)
+    chkNotIsOdd(chk, "4", 256)
+
+    chkNotIsOdd(chk, "A", 8)
+    chkNotIsOdd(chk, "AAA", 16)
+    chkNotIsOdd(chk, "AAAA", 32)
+    chkNotIsOdd(chk, "FFFFFA", 64)
+    chkNotIsOdd(chk, "FFFFFFFFFFFFFFA", 128)
+    chkNotIsOdd(chk, "FFFFFFFFFFFFFFFFFA", 256)
+
+  tst "operator `isEven`":
+    chkNotIsOdd(chk, "0", 8)
+    chkNotIsOdd(chk, "0", 16)
+    chkNotIsOdd(chk, "0", 32)
+    chkNotIsOdd(chk, "0", 64)
+    chkNotIsOdd(chk, "0", 128)
+    chkNotIsOdd(chk, "0", 256)
+
+    chkNotIsOdd(chk, "4", 8)
+    chkNotIsOdd(chk, "4", 16)
+    chkNotIsOdd(chk, "4", 32)
+    chkNotIsOdd(chk, "4", 64)
+    chkNotIsOdd(chk, "4", 128)
+    chkNotIsOdd(chk, "4", 256)
+
+    chkNotIsOdd(chk, "A", 8)
+    chkNotIsOdd(chk, "AAA", 16)
+    chkNotIsOdd(chk, "AAAA", 32)
+    chkNotIsOdd(chk, "FFFFFA", 64)
+    chkNotIsOdd(chk, "FFFFFFFFFFFFFFA", 128)
+    chkNotIsOdd(chk, "FFFFFFFFFFFFFFFFFA", 256)
+
+  tst "operator not `isEven`":
+    chkIsOdd(chk, "1", 8)
+    chkIsOdd(chk, "1", 16)
+    chkIsOdd(chk, "1", 32)
+    chkIsOdd(chk, "1", 64)
+    chkIsOdd(chk, "1", 128)
+    chkIsOdd(chk, "1", 256)
+
+    chkIsOdd(chk, "FF", 8)
+    chkIsOdd(chk, "FFF", 16)
+    chkIsOdd(chk, "FFFFF", 32)
+    chkIsOdd(chk, "FFFFFF", 64)
+    chkIsOdd(chk, "FFFFFFFFFFFFFFF", 128)
+    chkIsOdd(chk, "FFFFFFFFFFFFFFFFFF", 256)
+
+static:
+  testComparison(doAssert, ctTest)
+
+suite "Wider unsigned int comparison coverage":
+  testComparison(check, test)
+
 suite "Testing unsigned int comparison operators":
   let
     a = 10'i16.stuint(16)

--- a/tests/test_uint_endians2.nim
+++ b/tests/test_uint_endians2.nim
@@ -7,7 +7,78 @@
 #
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import ../stint, unittest
+import ../stint, unittest, stew/byteutils
+
+template chkSwapBytes(chk: untyped, bits: int, hex: string) =
+  # dumpHex already do the job to swap the output if
+  # we use `littleEndian` on both platform
+  # bigEndian:    B to B, B to L, L to B
+  # littleEndian: B to L, L to B, B to B
+  chk swapBytes(fromHex(StUint[bits], hex)).dumpHex(littleEndian) == hex
+
+template chkToBytes(chk: untyped, bits: int, hex: string) =
+  let x = fromHex(StUint[bits], hex)
+  chk toBytes(x).toHex() == x.dumpHex(system.cpuEndian)
+
+template chkToBytesLE(chk: untyped, bits: int, hex: string) =
+  let x = fromHex(StUint[bits], hex)
+  chk toBytes(x, littleEndian).toHex() == x.dumpHex(littleEndian)
+
+template chkToBytesBE(chk: untyped, bits: int, hex: string) =
+  let x = fromHex(StUint[bits], hex)
+  chk toBytes(x, bigEndian).toHex() == x.dumpHex(bigEndian)
+
+template chkFromBytes(chk: untyped, bits: int, hex: string) =
+  let x = fromHex(StUint[bits], hex)
+  let z = fromBytes(StUint[bits], toBytes(x))
+  chk z == x
+
+template chkFromBytesBE(chk: untyped, bits: int, hex: string) =
+  let x = fromHex(StUint[bits], hex)
+  let z = fromBytesBE(StUint[bits], toBytesBE(x))
+  chk z == x
+
+template chkFromBytesLE(chk: untyped, bits: int, hex: string) =
+  let x = fromHex(StUint[bits], hex)
+  let z = fromBytesLE(StUint[bits], toBytesLE(x))
+  chk z == x
+
+template chkFromToLE(chk: untyped, bits: int, hex: string) =
+  let x = fromHex(StUint[bits], hex)
+  let z = x.fromLE.toLE
+  chk z == x
+
+template chkFromToBE(chk: untyped, bits: int, hex: string) =
+  let x = fromHex(StUint[bits], hex)
+  let z = x.fromBE.toBE
+  chk z == x
+
+template chkEndians(chkFunc, tst, name: untyped) =
+  tst astToStr(name).substr(3):
+    name(chkFunc, 8, "ab")
+    name(chkFunc, 16, "abcd")
+    name(chkFunc, 32, "abcdef12")
+    name(chkFunc, 64, "abcdef1234567890")
+    name(chkFunc, 128, "abcdef1234567890abcdef1234567890")
+    name(chkFunc, 256, "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
+
+template testEndians(chkFunc, tst: untyped) =
+  chkEndians(chkFunc, tst, chkSwapBytes)
+  chkEndians(chkFunc, tst, chkToBytes)
+  chkEndians(chkFunc, tst, chkToBytesLE)
+  chkEndians(chkFunc, tst, chkToBytesBE)
+  chkEndians(chkFunc, tst, chkFromBytes)
+  chkEndians(chkFunc, tst, chkFromBytesLE)
+  chkEndians(chkFunc, tst, chkFromBytesBE)
+  chkEndians(chkFunc, tst, chkFromToLE)
+  chkEndians(chkFunc, tst, chkFromToBE)
+
+template ctTest(name: string, body: untyped) =
+  body
+  echo "[OK] compile time ", name
+
+static:
+  testEndians(doAssert, ctTest)
 
 suite "Testing endians":
   test "Endians give sane results":
@@ -24,3 +95,5 @@ suite "Testing endians":
 
       1.u128 == UInt128.fromBytesLE(
         [1'u8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+
+  testEndians(check, test)

--- a/tests/test_uint_endians2.nim
+++ b/tests/test_uint_endians2.nim
@@ -7,7 +7,7 @@
 #
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import ../stint, unittest, stew/byteutils
+import ../stint, unittest, stew/byteutils, test_helpers
 
 template chkSwapBytes(chk: untyped, bits: int, hex: string) =
   # dumpHex already do the job to swap the output if
@@ -73,12 +73,8 @@ template testEndians(chkFunc, tst: untyped) =
   chkEndians(chkFunc, tst, chkFromToLE)
   chkEndians(chkFunc, tst, chkFromToBE)
 
-template ctTest(name: string, body: untyped) =
-  body
-  echo "[OK] compile time ", name
-
 static:
-  testEndians(doAssert, ctTest)
+  testEndians(ctCheck, ctTest)
 
 suite "Testing endians":
   test "Endians give sane results":

--- a/tests/test_uint_exp.nim
+++ b/tests/test_uint_exp.nim
@@ -7,17 +7,13 @@
 #
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import ../stint, unittest, math
+import ../stint, unittest, math, test_helpers
 
 template chkPow(chk: untyped, a, b, c: string, bits: int) =
   chk pow(fromHex(Stuint[bits], a), fromHex(Stuint[bits], b)) == fromHex(Stuint[bits], c)
 
 template chkPow(chk: untyped, a: string, b: SomeInteger, c: string, bits: int) =
   chk pow(fromHex(Stuint[bits], a), b) == fromHex(Stuint[bits], c)
-
-template ctTest(name: string, body: untyped) =
-  body
-  echo "[OK] compile time ", name
 
 template testExp(chk, tst: untyped) =
   tst "BigInt BigInt Pow":
@@ -63,7 +59,7 @@ template testExp(chk, tst: untyped) =
     chkPow(chk, "FFFFF", 3, "ffffd00002fffff", 128)
 
 static:
-  testExp(doAssert, ctTest)
+  testExp(ctCheck, ctTest)
 
 suite "Wider unsigned int exp coverage":
   testExp(check, test)

--- a/tests/test_uint_exp.nim
+++ b/tests/test_uint_exp.nim
@@ -9,6 +9,65 @@
 
 import ../stint, unittest, math
 
+template chkPow(chk: untyped, a, b, c: string, bits: int) =
+  chk pow(fromHex(Stuint[bits], a), fromHex(Stuint[bits], b)) == fromHex(Stuint[bits], c)
+
+template chkPow(chk: untyped, a: string, b: SomeInteger, c: string, bits: int) =
+  chk pow(fromHex(Stuint[bits], a), b) == fromHex(Stuint[bits], c)
+
+template ctTest(name: string, body: untyped) =
+  body
+  echo "[OK] compile time ", name
+
+template testExp(chk, tst: untyped) =
+  tst "BigInt BigInt Pow":
+    chkPow(chk, "F", "2", "E1", 8)
+
+    chkPow(chk, "F", "2", "E1", 16)
+    chkPow(chk, "FF", "2", "FE01", 16)
+
+    chkPow(chk, "F", "2", "E1", 32)
+    chkPow(chk, "FF", "2", "FE01", 32)
+    chkPow(chk, "FF", "3", "FD02FF", 32)
+
+    chkPow(chk, "F", "2", "E1", 64)
+    chkPow(chk, "FF", "2", "FE01", 64)
+    chkPow(chk, "FF", "3", "FD02FF", 64)
+    chkPow(chk, "FFF", "3", "FFD002FFF", 64)
+
+    chkPow(chk, "F", "2", "E1", 128)
+    chkPow(chk, "FF", "2", "FE01", 128)
+    chkPow(chk, "FF", "3", "FD02FF", 128)
+    chkPow(chk, "FFF", "3", "FFD002FFF", 128)
+    chkPow(chk, "FFFFF", "3", "ffffd00002fffff", 128)
+
+  tst "BigInt Natural Pow":
+    chkPow(chk, "F", 2, "E1", 8)
+
+    chkPow(chk, "F", 2, "E1", 16)
+    chkPow(chk, "FF", 2, "FE01", 16)
+
+    chkPow(chk, "F", 2, "E1", 32)
+    chkPow(chk, "FF", 2, "FE01", 32)
+    chkPow(chk, "FF", 3, "FD02FF", 32)
+
+    chkPow(chk, "F", 2, "E1", 64)
+    chkPow(chk, "FF", 2, "FE01", 64)
+    chkPow(chk, "FF", 3, "FD02FF", 64)
+    chkPow(chk, "FFF", 3, "FFD002FFF", 64)
+
+    chkPow(chk, "F", 2, "E1", 128)
+    chkPow(chk, "FF", 2, "FE01", 128)
+    chkPow(chk, "FF", 3, "FD02FF", 128)
+    chkPow(chk, "FFF", 3, "FFD002FFF", 128)
+    chkPow(chk, "FFFFF", 3, "ffffd00002fffff", 128)
+
+static:
+  testExp(doAssert, ctTest)
+
+suite "Wider unsigned int exp coverage":
+  testExp(check, test)
+
 suite "Testing unsigned exponentiation":
   test "Simple exponentiation 5^3":
 

--- a/tests/test_uint_modular_arithmetic.nim
+++ b/tests/test_uint_modular_arithmetic.nim
@@ -7,7 +7,7 @@
 #
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import ../stint, unittest, math
+import ../stint, unittest, math, test_helpers
 
 template chkAddmod(chk: untyped, a, b, m, c: string, bits: int) =
   chk addmod(fromHex(Stuint[bits], a), fromHex(Stuint[bits], b),  fromHex(Stuint[bits], m)) == fromHex(Stuint[bits], c)
@@ -20,10 +20,6 @@ template chkMulmod(chk: untyped, a, b, m, c: string, bits: int) =
 
 template chkPowmod(chk: untyped, a, b, m, c: string, bits: int) =
   chk powmod(fromHex(Stuint[bits], a), fromHex(Stuint[bits], b),  fromHex(Stuint[bits], m)) == fromHex(Stuint[bits], c)
-
-template ctTest(name: string, body: untyped) =
-  body
-  echo "[OK] compile time ", name
 
 template testModArith(chk, tst: untyped) =
   tst "addmod":
@@ -141,7 +137,7 @@ template testModArith(chk, tst: untyped) =
     chkPowMod(chk, "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "3", "C", "3", 128)
 
 static:
-  testModArith(doAssert, ctTest)
+  testModArith(ctCheck, ctTest)
 
 suite "Wider unsigned Modular arithmetic coverage":
   testModArith(check, test)

--- a/tests/test_uint_modular_arithmetic.nim
+++ b/tests/test_uint_modular_arithmetic.nim
@@ -9,6 +9,143 @@
 
 import ../stint, unittest, math
 
+template chkAddmod(chk: untyped, a, b, m, c: string, bits: int) =
+  chk addmod(fromHex(Stuint[bits], a), fromHex(Stuint[bits], b),  fromHex(Stuint[bits], m)) == fromHex(Stuint[bits], c)
+
+template chkSubmod(chk: untyped, a, b, m, c: string, bits: int) =
+  chk submod(fromHex(Stuint[bits], a), fromHex(Stuint[bits], b),  fromHex(Stuint[bits], m)) == fromHex(Stuint[bits], c)
+
+template chkMulmod(chk: untyped, a, b, m, c: string, bits: int) =
+  chk mulmod(fromHex(Stuint[bits], a), fromHex(Stuint[bits], b),  fromHex(Stuint[bits], m)) == fromHex(Stuint[bits], c)
+
+template chkPowmod(chk: untyped, a, b, m, c: string, bits: int) =
+  chk powmod(fromHex(Stuint[bits], a), fromHex(Stuint[bits], b),  fromHex(Stuint[bits], m)) == fromHex(Stuint[bits], c)
+
+template ctTest(name: string, body: untyped) =
+  body
+  echo "[OK] compile time ", name
+
+template testModArith(chk, tst: untyped) =
+  tst "addmod":
+    chkAddMod(chk, "F", "F", "7", "2", 8)
+    chkAddMod(chk, "AAAA", "AA", "F", "0", 16)
+    chkAddMod(chk, "BBBB", "AAAA", "9", "3", 16)
+
+    chkAddMod(chk, "F", "F", "7", "2", 32)
+    chkAddMod(chk, "AAAA", "AA", "F", "0", 32)
+    chkAddMod(chk, "BBBB", "AAAA", "9", "3", 32)
+    chkAddMod(chk, "BBBBBBBB", "AAAAAAAA", "9", "6", 32)
+
+    chkAddMod(chk, "F", "F", "7", "2", 64)
+    chkAddMod(chk, "AAAA", "AA", "F", "0", 64)
+    chkAddMod(chk, "BBBB", "AAAA", "9", "3", 64)
+    chkAddMod(chk, "BBBBBBBB", "AAAAAAAA", "9", "6", 64)
+    chkAddMod(chk, "BBBBBBBBBBBBBBBB", "AAAAAAAAAAAAAAAA", "9", "3", 64)
+
+    chkAddMod(chk, "F", "F", "7", "2", 128)
+    chkAddMod(chk, "AAAA", "AA", "F", "0", 128)
+    chkAddMod(chk, "BBBB", "AAAA", "9", "3", 128)
+    chkAddMod(chk, "BBBBBBBB", "AAAAAAAA", "9", "6", 128)
+    chkAddMod(chk, "BBBBBBBBBBBBBBBB", "AAAAAAAAAAAAAAAA", "9", "3", 128)
+    chkAddMod(chk, "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", "9", "6", 128)
+
+
+  tst "submod":
+    chkSubMod(chk, "C", "3", "C", "9", 8)
+    chkSubMod(chk, "1", "3", "C", "A", 8)
+    chkSubMod(chk, "1", "FF", "C", "A", 8)
+
+    chkSubMod(chk, "C", "3", "C", "9", 16)
+    chkSubMod(chk, "1", "3", "C", "A", 16)
+    chkSubMod(chk, "1", "FFFF", "C", "A", 32)
+
+    chkSubMod(chk, "C", "3", "C", "9", 32)
+    chkSubMod(chk, "1", "3", "C", "A", 32)
+    chkSubMod(chk, "1", "FFFF", "C", "A", 32)
+    chkSubMod(chk, "1", "FFFFFFFF", "C", "A", 32)
+
+    chkSubMod(chk, "C", "3", "C", "9", 64)
+    chkSubMod(chk, "1", "3", "C", "A", 64)
+    chkSubMod(chk, "1", "FFFF", "C", "A", 64)
+    chkSubMod(chk, "1", "FFFFFFFF", "C", "A", 64)
+    chkSubMod(chk, "1", "FFFFFFFFFFFFFFFF", "C", "A", 64)
+
+    chkSubMod(chk, "C", "3", "C", "9", 128)
+    chkSubMod(chk, "1", "3", "C", "A", 128)
+    chkSubMod(chk, "1", "FFFF", "C", "A", 128)
+    chkSubMod(chk, "1", "FFFFFFFF", "C", "A", 128)
+    chkSubMod(chk, "1", "FFFFFFFFFFFFFFFF", "C", "A", 128)
+    chkSubMod(chk, "1", "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "C", "A", 128)
+
+  tst "mulmod":
+    chkMulMod(chk, "C", "3", "C", "0", 8)
+    chkMulMod(chk, "1", "3", "C", "3", 8)
+    chkMulMod(chk, "1", "FF", "C", "3", 8)
+
+    chkMulMod(chk, "C", "3", "C", "0", 16)
+    chkMulMod(chk, "1", "3", "C", "3", 16)
+    chkMulMod(chk, "1", "FFFF", "C", "3", 16)
+
+    chkMulMod(chk, "C", "3", "C", "0", 32)
+    chkMulMod(chk, "1", "3", "C", "3", 32)
+    chkMulMod(chk, "1", "FFFF", "C", "3", 32)
+    chkMulMod(chk, "1", "FFFFFFFF", "C", "3", 32)
+
+    chkMulMod(chk, "C", "3", "C", "0", 64)
+    chkMulMod(chk, "1", "3", "C", "3", 64)
+    chkMulMod(chk, "1", "FFFF", "C", "3", 64)
+    chkMulMod(chk, "1", "FFFFFFFF", "C", "3", 64)
+    chkMulMod(chk, "1", "FFFFFFFFFFFFFFFF", "C", "3", 64)
+
+    chkMulMod(chk, "C", "3", "C", "0", 128)
+    chkMulMod(chk, "1", "3", "C", "3", 128)
+    chkMulMod(chk, "1", "FFFF", "C", "3", 128)
+    chkMulMod(chk, "1", "FFFFFFFF", "C", "3", 128)
+    chkMulMod(chk, "1", "FFFFFFFFFFFFFFFF", "C", "3", 128)
+    chkMulMod(chk, "1", "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "C", "3", 128)
+
+  tst "powmod":
+    chkPowMod(chk, "C", "3", "C", "0", 8)
+    chkPowMod(chk, "1", "3", "C", "1", 8)
+    chkPowMod(chk, "1", "FF", "C", "1", 8)
+    chkPowMod(chk, "FF", "3", "C", "3", 8)
+
+    chkPowMod(chk, "C", "3", "C", "0", 16)
+    chkPowMod(chk, "1", "3", "C", "1", 16)
+    chkPowMod(chk, "1", "FF", "C", "1", 16)
+    chkPowMod(chk, "FF", "3", "C", "3", 16)
+    chkPowMod(chk, "FFFF", "3", "C", "3", 16)
+
+    chkPowMod(chk, "C", "3", "C", "0", 32)
+    chkPowMod(chk, "1", "3", "C", "1", 32)
+    chkPowMod(chk, "1", "FF", "C", "1", 32)
+    chkPowMod(chk, "FF", "3", "C", "3", 32)
+    chkPowMod(chk, "FFFF", "3", "C", "3", 32)
+    chkPowMod(chk, "FFFFFFFF", "3", "C", "3", 32)
+
+    chkPowMod(chk, "C", "3", "C", "0", 64)
+    chkPowMod(chk, "1", "3", "C", "1", 64)
+    chkPowMod(chk, "1", "FF", "C", "1", 64)
+    chkPowMod(chk, "FF", "3", "C", "3", 64)
+    chkPowMod(chk, "FFFF", "3", "C", "3", 64)
+    chkPowMod(chk, "FFFFFFFF", "3", "C", "3", 64)
+    chkPowMod(chk, "FFFFFFFFFFFFFFFF", "3", "C", "3", 64)
+
+    chkPowMod(chk, "C", "3", "C", "0", 128)
+    chkPowMod(chk, "1", "3", "C", "1", 128)
+    chkPowMod(chk, "1", "FF", "C", "1", 128)
+    chkPowMod(chk, "FF", "3", "C", "3", 128)
+    chkPowMod(chk, "FFFF", "3", "C", "3", 128)
+    chkPowMod(chk, "FFFFFFFF", "3", "C", "3", 128)
+    chkPowMod(chk, "FFFFFFFFFFFFFFFF", "3", "C", "3", 128)
+    chkPowMod(chk, "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "3", "C", "3", 128)
+
+static:
+  testModArith(doAssert, ctTest)
+
+suite "Wider unsigned Modular arithmetic coverage":
+  testModArith(check, test)
+
 suite "Modular arithmetic":
   test "Modular addition":
 

--- a/tests/test_uint_muldiv.nim
+++ b/tests/test_uint_muldiv.nim
@@ -7,7 +7,7 @@
 #
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import ../stint, unittest
+import ../stint, unittest, test_helpers
 
 template chkMul(chk: untyped, a, b, c: string, bits: int) =
   chk (fromHex(Stuint[bits], a) * fromHex(Stuint[bits], b)) == fromHex(Stuint[bits], c)
@@ -20,10 +20,6 @@ template chkMod(chk: untyped, a, b, c: string, bits: int) =
 
 template chkDivMod(chk: untyped, a, b, c, d: string, bits: int) =
   chk divmod(fromHex(Stuint[bits], a), fromHex(Stuint[bits], b)) == (fromHex(Stuint[bits], c), fromHex(Stuint[bits], d))
-
-template ctTest(name: string, body: untyped) =
-  body
-  echo "[OK] compile time ", name
 
 template testMuldiv(chk, tst: untyped) =
   tst "operator `mul`":
@@ -216,7 +212,7 @@ template testMuldiv(chk, tst: untyped) =
     chkDivMod(chk, "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "27", "6906906906906906906906906906906", "15", 128)
 
 static:
-  testMuldiv(doAssert, ctTest)
+  testMuldiv(ctCheck, ctTest)
 
 suite "Wider unsigned int muldiv coverage":
   testMuldiv(check, test)

--- a/tests/test_uint_muldiv.nim
+++ b/tests/test_uint_muldiv.nim
@@ -9,6 +9,32 @@
 
 import ../stint, unittest
 
+template chkMul(chk: untyped, a, b, c: string, bits: int) =
+  chk (fromHex(Stuint[bits], a) * fromHex(Stuint[bits], b)) == fromHex(Stuint[bits], c)
+
+template chkDiv(chk: untyped, a, b, c: string, bits: int) =
+  chk (fromHex(Stuint[bits], a) div fromHex(Stuint[bits], b)) == fromHex(Stuint[bits], c)
+  
+template chkMod(chk: untyped, a, b, c: string, bits: int) =
+  chk (fromHex(Stuint[bits], a) mod fromHex(Stuint[bits], b)) == fromHex(Stuint[bits], c)
+
+template chkDivMod(chk: untyped, a, b, c, d: string, bits: int) =
+  chk (fromHex(Stuint[bits], a) divmod fromHex(Stuint[bits], b)) == (fromHex(Stuint[bits], c), fromHex(Stuint[bits], d))
+  
+template testMuldiv(chk, tst: untyped) =
+  tst "operator `mul`":
+    chkMul(chk, "0", "3", "0", 8)
+    
+  #tst "operator `div`":
+  #tst "operator `mod`":
+  #tst "operator `divmod`":
+  
+static:
+  testMuldiv(doAssert, ctTest)
+
+suite "Wider unsigned int muldiv coverage":
+  testMuldiv(check, test)
+  
 suite "Testing unsigned int multiplication implementation":
   test "Multiplication with result fitting in low half":
 

--- a/tests/test_uint_muldiv.nim
+++ b/tests/test_uint_muldiv.nim
@@ -14,27 +14,213 @@ template chkMul(chk: untyped, a, b, c: string, bits: int) =
 
 template chkDiv(chk: untyped, a, b, c: string, bits: int) =
   chk (fromHex(Stuint[bits], a) div fromHex(Stuint[bits], b)) == fromHex(Stuint[bits], c)
-  
+
 template chkMod(chk: untyped, a, b, c: string, bits: int) =
   chk (fromHex(Stuint[bits], a) mod fromHex(Stuint[bits], b)) == fromHex(Stuint[bits], c)
 
 template chkDivMod(chk: untyped, a, b, c, d: string, bits: int) =
-  chk (fromHex(Stuint[bits], a) divmod fromHex(Stuint[bits], b)) == (fromHex(Stuint[bits], c), fromHex(Stuint[bits], d))
-  
+  chk divmod(fromHex(Stuint[bits], a), fromHex(Stuint[bits], b)) == (fromHex(Stuint[bits], c), fromHex(Stuint[bits], d))
+
+template ctTest(name: string, body: untyped) =
+  body
+  echo "[OK] compile time ", name
+
 template testMuldiv(chk, tst: untyped) =
   tst "operator `mul`":
     chkMul(chk, "0", "3", "0", 8)
-    
-  #tst "operator `div`":
-  #tst "operator `mod`":
-  #tst "operator `divmod`":
-  
+    chkMul(chk, "1", "3", "3", 8)
+    chkMul(chk, "64", "3", "2C", 8) # overflow
+
+    chkMul(chk, "0", "3", "0", 16)
+    chkMul(chk, "1", "3", "3", 16)
+    chkMul(chk, "64", "3", "12C", 16)
+    chkMul(chk, "1770", "46", "68A0", 16) # overflow
+
+    chkMul(chk, "0", "3", "0", 32)
+    chkMul(chk, "1", "3", "3", 32)
+    chkMul(chk, "64", "3", "12C", 32)
+    chkMul(chk, "1770", "46", "668A0", 32)
+    chkMul(chk, "13880", "13880", "7D784000", 32) # overflow
+
+    chkMul(chk, "0", "3", "0", 64)
+    chkMul(chk, "1", "3", "3", 64)
+    chkMul(chk, "64", "3", "12C", 64)
+    chkMul(chk, "1770", "46", "668A0", 64)
+    chkMul(chk, "13880", "13880", "17D784000", 64)
+    chkMul(chk, "3B9ACA00", "E8D4A51000", "35C9ADC5DEA00000", 64) # overflow
+
+    chkMul(chk, "0", "3", "0", 128)
+    chkMul(chk, "1", "3", "3", 128)
+    chkMul(chk, "64", "3", "12C", 128)
+    chkMul(chk, "1770", "46", "668A0", 128)
+    chkMul(chk, "13880", "13880", "17D784000", 128)
+    chkMul(chk, "3B9ACA00", "E8D4A51000", "3635C9ADC5DEA00000", 128)
+    chkMul(chk, "25295F0D1", "10", "25295F0D10", 128)
+    chkMul(chk, "123456789ABCDEF00", "123456789ABCDEF00", "4b66dc33f6acdca5e20890f2a5210000", 128) # overflow
+
+    chkMul(chk, "123456789ABCDEF00", "123456789ABCDEF00", "14b66dc33f6acdca5e20890f2a5210000", 256)
+
+  tst "operator `div`":
+    chkDiv(chk, "0", "3", "0", 8)
+    chkDiv(chk, "1", "3", "0", 8)
+    chkDiv(chk, "3", "3", "1", 8)
+    chkDiv(chk, "3", "1", "3", 8)
+    chkDiv(chk, "FF", "3", "55", 8)
+
+    chkDiv(chk, "0", "3", "0", 16)
+    chkDiv(chk, "1", "3", "0", 16)
+    chkDiv(chk, "3", "3", "1", 16)
+    chkDiv(chk, "3", "1", "3", 16)
+    chkDiv(chk, "FF", "3", "55", 16)
+    chkDiv(chk, "FFFF", "3", "5555", 16)
+
+    chkDiv(chk, "0", "3", "0", 32)
+    chkDiv(chk, "1", "3", "0", 32)
+    chkDiv(chk, "3", "3", "1", 32)
+    chkDiv(chk, "3", "1", "3", 32)
+    chkDiv(chk, "FF", "3", "55", 32)
+    chkDiv(chk, "FFFF", "3", "5555", 32)
+    chkDiv(chk, "FFFFFFFF", "3", "55555555", 32)
+
+    chkDiv(chk, "0", "3", "0", 64)
+    chkDiv(chk, "1", "3", "0", 64)
+    chkDiv(chk, "3", "3", "1", 64)
+    chkDiv(chk, "3", "1", "3", 64)
+    chkDiv(chk, "FF", "3", "55", 64)
+    chkDiv(chk, "FFFF", "3", "5555", 64)
+    chkDiv(chk, "FFFFFFFF", "3", "55555555", 64)
+    chkDiv(chk, "FFFFFFFFFFFFFFFF", "3", "5555555555555555", 64)
+
+    chkDiv(chk, "0", "3", "0", 128)
+    chkDiv(chk, "1", "3", "0", 128)
+    chkDiv(chk, "3", "3", "1", 128)
+    chkDiv(chk, "3", "1", "3", 128)
+    chkDiv(chk, "FF", "3", "55", 128)
+    chkDiv(chk, "FFFF", "3", "5555", 128)
+    chkDiv(chk, "FFFFFFFF", "3", "55555555", 128)
+    chkDiv(chk, "FFFFFFFFFFFFFFFF", "3", "5555555555555555", 128)
+    chkDiv(chk, "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "3", "55555555555555555555555555555555", 128)
+
+  tst "operator `mod`":
+    chkMod(chk, "0", "3", "0", 8)
+    chkMod(chk, "1", "3", "1", 8)
+    chkMod(chk, "3", "3", "0", 8)
+    chkMod(chk, "3", "1", "0", 8)
+    chkMod(chk, "FF", "3", "0", 8)
+    chkMod(chk, "FF", "4", "3", 8)
+
+    chkMod(chk, "0", "3", "0", 16)
+    chkMod(chk, "1", "3", "1", 16)
+    chkMod(chk, "3", "3", "0", 16)
+    chkMod(chk, "3", "1", "0", 16)
+    chkMod(chk, "FF", "3", "0", 16)
+    chkMod(chk, "FF", "4", "3", 16)
+    chkMod(chk, "FFFF", "3", "0", 16)
+    chkMod(chk, "FFFF", "4", "3", 16)
+    chkMod(chk, "FFFF", "17", "8", 16)
+
+    chkMod(chk, "0", "3", "0", 32)
+    chkMod(chk, "1", "3", "1", 32)
+    chkMod(chk, "3", "3", "0", 32)
+    chkMod(chk, "3", "1", "0", 32)
+    chkMod(chk, "FF", "3", "0", 32)
+    chkMod(chk, "FF", "4", "3", 32)
+    chkMod(chk, "FFFF", "3", "0", 32)
+    chkMod(chk, "FFFF", "17", "8", 32)
+    chkMod(chk, "FFFFFFFF", "3", "0", 32)
+    chkMod(chk, "FFFFFFFF", "23", "A", 32)
+    chkMod(chk, "FFFFFFFF", "27", "15", 32)
+
+    chkMod(chk, "0", "3", "0", 64)
+    chkMod(chk, "1", "3", "1", 64)
+    chkMod(chk, "3", "3", "0", 64)
+    chkMod(chk, "3", "1", "0", 64)
+    chkMod(chk, "FF", "3", "0", 64)
+    chkMod(chk, "FF", "4", "3", 64)
+    chkMod(chk, "FFFF", "3", "0", 64)
+    chkMod(chk, "FFFF", "17", "8", 64)
+    chkMod(chk, "FFFFFFFF", "3", "0", 64)
+    chkMod(chk, "FFFFFFFF", "23", "A", 64)
+    chkMod(chk, "FFFFFFFF", "27", "15", 64)
+    chkMod(chk, "FFFFFFFFFFFFFFFF", "27", "F", 64)
+
+    chkMod(chk, "0", "3", "0", 128)
+    chkMod(chk, "1", "3", "1", 128)
+    chkMod(chk, "3", "3", "0", 128)
+    chkMod(chk, "3", "1", "0", 128)
+    chkMod(chk, "FF", "3", "0", 128)
+    chkMod(chk, "FF", "4", "3", 128)
+    chkMod(chk, "FFFF", "3", "0", 128)
+    chkMod(chk, "FFFF", "17", "8", 128)
+    chkMod(chk, "FFFFFFFF", "3", "0", 128)
+    chkMod(chk, "FFFFFFFF", "23", "A", 128)
+    chkMod(chk, "FFFFFFFF", "27", "15", 128)
+    chkMod(chk, "FFFFFFFFFFFFFFFF", "27", "F", 128)
+    chkMod(chk, "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "27", "15", 128)
+
+  tst "operator `divmod`":
+    chkDivMod(chk, "0", "3", "0", "0", 8)
+    chkDivMod(chk, "1", "3", "0", "1", 8)
+    chkDivMod(chk, "3", "3", "1", "0", 8)
+    chkDivMod(chk, "3", "1", "3", "0", 8)
+    chkDivMod(chk, "FF", "3", "55", "0", 8)
+    chkDivMod(chk, "FF", "4", "3F", "3", 8)
+
+    chkDivMod(chk, "0", "3", "0", "0", 16)
+    chkDivMod(chk, "1", "3", "0", "1", 16)
+    chkDivMod(chk, "3", "3", "1", "0", 16)
+    chkDivMod(chk, "3", "1", "3", "0", 16)
+    chkDivMod(chk, "FF", "3", "55", "0", 16)
+    chkDivMod(chk, "FF", "4", "3F", "3", 16)
+    chkDivMod(chk, "FFFF", "3", "5555", "0", 16)
+    chkDivMod(chk, "FFFF", "4", "3FFF", "3", 16)
+    chkDivMod(chk, "FFFF", "17", "B21", "8", 16)
+
+    chkDivMod(chk, "0", "3", "0", "0", 32)
+    chkDivMod(chk, "1", "3", "0", "1", 32)
+    chkDivMod(chk, "3", "3", "1", "0", 32)
+    chkDivMod(chk, "3", "1", "3", "0", 32)
+    chkDivMod(chk, "FF", "3", "55", "0", 32)
+    chkDivMod(chk, "FF", "4", "3F", "3", 32)
+    chkDivMod(chk, "FFFF", "3", "5555", "0", 32)
+    chkDivMod(chk, "FFFF", "17", "B21", "8", 32)
+    chkDivMod(chk, "FFFFFFFF", "3", "55555555", "0", 32)
+    chkDivMod(chk, "FFFFFFFF", "23", "7507507", "0A", 32)
+    chkDivMod(chk, "FFFFFFFF", "27", "6906906", "15", 32)
+
+    chkDivMod(chk, "0", "3", "0", "0", 64)
+    chkDivMod(chk, "1", "3", "0", "1", 64)
+    chkDivMod(chk, "3", "3", "1", "0", 64)
+    chkDivMod(chk, "3", "1", "3", "0", 64)
+    chkDivMod(chk, "FF", "3", "55", "0", 64)
+    chkDivMod(chk, "FF", "4", "3F", "3", 64)
+    chkDivMod(chk, "FFFF", "3", "5555", "0", 64)
+    chkDivMod(chk, "FFFF", "17", "B21", "8", 64)
+    chkDivMod(chk, "FFFFFFFF", "3", "55555555", "0", 64)
+    chkDivMod(chk, "FFFFFFFF", "23", "7507507", "0A", 64)
+    chkDivMod(chk, "FFFFFFFF", "27", "6906906", "15", 64)
+    chkDivMod(chk, "FFFFFFFFFFFFFFFF", "27", "690690690690690", "F", 64)
+
+    chkDivMod(chk, "0", "3", "0", "0", 128)
+    chkDivMod(chk, "1", "3", "0", "1", 128)
+    chkDivMod(chk, "3", "3", "1", "0", 128)
+    chkDivMod(chk, "3", "1", "3", "0", 128)
+    chkDivMod(chk, "FF", "3", "55", "0", 128)
+    chkDivMod(chk, "FF", "4", "3F", "3", 128)
+    chkDivMod(chk, "FFFF", "3", "5555", "0", 128)
+    chkDivMod(chk, "FFFF", "17", "B21", "8", 128)
+    chkDivMod(chk, "FFFFFFFF", "3", "55555555", "0", 128)
+    chkDivMod(chk, "FFFFFFFF", "23", "7507507", "0A", 128)
+    chkDivMod(chk, "FFFFFFFF", "27", "6906906", "15", 128)
+    chkDivMod(chk, "FFFFFFFFFFFFFFFF", "27", "690690690690690", "F", 128)
+    chkDivMod(chk, "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "27", "6906906906906906906906906906906", "15", 128)
+
 static:
   testMuldiv(doAssert, ctTest)
 
 suite "Wider unsigned int muldiv coverage":
   testMuldiv(check, test)
-  
+
 suite "Testing unsigned int multiplication implementation":
   test "Multiplication with result fitting in low half":
 
@@ -56,7 +242,13 @@ suite "Testing unsigned int multiplication implementation":
     let b = 1_000_000_000.stuint(64)
     let c = 1_000.stuint(64)
 
-    check: cast[uint64](a*b*c) == 1_000_000_000_000_000_000_000'u64 # need 70-bits
+    let x = 1_000_000_000'u64
+    let y = 1_000_000_000'u64
+    let z = 1_000'u64
+    let w = x*y*z
+
+    #check: cast[uint64](a*b*c) == 1_000_000_000_000_000_000_000'u64 # need 70-bits
+    check: cast[uint64](a*b*c) == w
 
   test "Nim v1.0.2 32 bit type inference rule changed":
     let x = 9975492817.stuint(256)


### PR DESCRIPTION
The goal of this  PR is to have 100% coverage for all exported API to pass compile time test.
The compile time helpers implementation might be not efficient, but first make it run then make it run fast.
As a bonus, it also improve runtime coverage.
zero, negative numbers, hi and lo tests also added if possible.
Inputs are welcome.

- [x] uint bitops2
- [x] uint endians2
- [x] io
- [x] int addsub
- [x] int bitwise
- [x] int comparison
- [x] int muldiv
- [x] uint addsub
- [x] uint bitwise
- [x] uint comparison
- [x] uint exp
- [x] uint modular arithmetic
- [x] uint muldiv
