### PR TITLE
fix stint for https://github.com/nim-lang/Nim/pull/18050

### DIFF
--- a/stint/private/datatypes.nim
+++ b/stint/private/datatypes.nim
@@ -123,6 +123,7 @@ when defined(mpint_test): # TODO stint_test
 
 else:
   template uintImpl*(bits: static[int]): untyped =
+    mixin UintImpl
     when bits >= 128: UintImpl[uintImpl(checkDiv2(bits))]
     elif bits == 64: uint64
     elif bits == 32: uint32


### PR DESCRIPTION
unblocks https://github.com/nim-lang/Nim/pull/18050 which fixes the long-standing generic sandwich problem in nim

this is forward and backward compatible.

## note
https://github.com/nim-lang/Nim/pull/18050 also addresses the following:
> export IntImpl, intImpl, UintImpl, uintImpl, bitsof # TODO: remove the need to export those

by binding symbol `uintImpl` from where it's called in:
```nim
type
  StUint*[bits: static[int]] = object
    data*: uintImpl(bits)
```
so that `uintImpl` won't need to be exposed to clients of `StUint`