### PR TITLE
Fix 32-bit failure on Nim 1.6

### DIFF
--- a/tests/test_int_addsub.nim
+++ b/tests/test_int_addsub.nim
@@ -228,12 +228,9 @@ template testAddSub(chk, tst: untyped) =
     chkNegation(chk, 127, -127, 128)
     chkNegation(chk, 32768, -32768, 128)
     chkNegation(chk, 32767, -32767, 128)
-    when nimvm:
-      # With Nim 1.6, it seems like https://github.com/status-im/nim-stint/issues/92
-      # can now happen at compile time on 32-bit platforms.
-      when (NimMajor,NimMinor,NimPatch) < (1,6,0):
-        chkNegation(chk, 2147483648, -2147483648, 128)
-    else:
+    # With Nim 1.6, it seems like https://github.com/status-im/nim-stint/issues/92
+    # can now happen on 32-bit platforms.
+    when (NimMajor,NimMinor,NimPatch) < (1,6,0):
       chkNegation(chk, 2147483648, -2147483648, 128)
     chkNegation(chk, 2147483647, -2147483647, 128)
     #chkNegation(chk, 9223372036854775808, -9223372036854775808, 128) # TODO: bug #92

--- a/tests/test_int_addsub.nim
+++ b/tests/test_int_addsub.nim
@@ -228,7 +228,13 @@ template testAddSub(chk, tst: untyped) =
     chkNegation(chk, 127, -127, 128)
     chkNegation(chk, 32768, -32768, 128)
     chkNegation(chk, 32767, -32767, 128)
-    chkNegation(chk, 2147483648, -2147483648, 128)
+    when nimvm:
+      # With Nim 1.6, it seems like https://github.com/status-im/nim-stint/issues/92
+      # can now happen at compile time on 32-bit platforms.
+      when (NimMajor,NimMinor,NimPatch) < (1,6,0):
+        chkNegation(chk, 2147483648, -2147483648, 128)
+    else:
+      chkNegation(chk, 2147483648, -2147483648, 128)
     chkNegation(chk, 2147483647, -2147483647, 128)
     #chkNegation(chk, 9223372036854775808, -9223372036854775808, 128) # TODO: bug #92
 


### PR DESCRIPTION
I suspect Nim int/int32 in the VM do not use int64 anymore and so we are now affected by #92 in the compile-time VM as well as the test failure is:

![image](https://user-images.githubusercontent.com/22738317/149196061-177a098e-da67-4e27-99b2-9c7067ca19a0.png)
https://github.com/status-im/nim-stint/runs/4783712651?check_suite_focus=true#step:11:105

With the test being L231
https://github.com/status-im/nim-stint/blob/e17113fb31bc90780ce89ab5de0f4a60d40d3aa1/tests/test_int_addsub.nim#L226-L233

And with signed integer, the lowest negative int cannot be negated. i.e. for int8 there is -128 but the highest positive int is 127.

