### PR TITLE
update GitHub Actions CI images from deprecated Ubuntu 18.04 to 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         include:
           - target:
               os: linux
-            builder: ubuntu-18.04
+            builder: ubuntu-20.04
             shell: bash
           - target:
               os: macos


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/6002