### PR TITLE
fix(skipPrefixes): fix erroneous strip of 0b in hex numbers

### DIFF
--- a/stint/io.nim
+++ b/stint/io.nim
@@ -226,9 +226,10 @@ func skipPrefixes(current_idx: var int, str: string, radix: range[2..16]) {.inli
         raise newException(ValueError, "Parsing mismatch, 0o prefix is only valid for an octal number (base 8)")
       current_idx = 2
     elif str[1] in {'b', 'B'}:
-      if radix != 2:
-        raise newException(ValueError, "Parsing mismatch, 0b prefix is only valid for a binary number (base 2)")
-      current_idx = 2
+      if radix notin {2, 16}:
+        raise newException(ValueError, "Parsing mismatch, 0b prefix is only valid for a binary number (base 2) or as first byte of a hexadecimal number (base 16)")
+      if radix == 2:
+        current_idx = 2
 
 func nextNonBlank(current_idx: var int, s: string) {.inline.} =
   ## Move the current index, skipping white spaces and "_" characters.

--- a/stint/io.nim
+++ b/stint/io.nim
@@ -218,18 +218,20 @@ func skipPrefixes(current_idx: var int, str: string, radix: range[2..16]) {.inli
   doAssert current_idx == 0, "skipPrefixes only works for prefixes (position 0 and 1 of the string)"
   if str[0] == '0':
     if str[1] in {'x', 'X'}:
-      if radix != 16:
+      if radix == 16:
+        current_idx = 2
+      else:
         raise newException(ValueError,"Parsing mismatch, 0x prefix is only valid for a hexadecimal number (base 16)")
-      current_idx = 2
     elif str[1] in {'o', 'O'}:
-      if radix != 8:
+      if radix == 8:
+        current_idx = 2
+      else:
         raise newException(ValueError, "Parsing mismatch, 0o prefix is only valid for an octal number (base 8)")
-      current_idx = 2
     elif str[1] in {'b', 'B'}:
-      if radix notin {2, 16}:
-        raise newException(ValueError, "Parsing mismatch, 0b prefix is only valid for a binary number (base 2) or as first byte of a hexadecimal number (base 16)")
       if radix == 2:
         current_idx = 2
+      elif radix != 16:
+        raise newException(ValueError, "Parsing mismatch, 0b prefix is only valid for a binary number (base 2) or as first byte of a hexadecimal number (base 16)")
 
 func nextNonBlank(current_idx: var int, s: string) {.inline.} =
   ## Move the current index, skipping white spaces and "_" characters.

--- a/tests/test_io.nim
+++ b/tests/test_io.nim
@@ -1172,8 +1172,8 @@ proc main() =
         check: -1'i16 == cast[int16](a)
 
       block:
-        let a = "0b1234abcdef".parse(StInt[16], 16)
-        let b = "0x0b1234abcdef".parse(StInt[16], 16)
+        let a = "0b1234abcdef".parse(StInt[64], 16)
+        let b = "0x0b1234abcdef".parse(StInt[64], 16)
         let c = 0x0b1234abcdef.stint(64)
 
         check: a == b

--- a/tests/test_io.nim
+++ b/tests/test_io.nim
@@ -7,7 +7,7 @@
 #
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import ../stint, unittest, strutils, math, test_helpers, tables
+import ../stint, unittest, strutils, math, test_helpers, tables, std/strformat
 
 template nativeStuint(chk, nint: untyped, bits: int) =
   chk $(nint.stuint(bits)) == $(nint)
@@ -1090,23 +1090,79 @@ proc main() =
         check: a == b
         check: -123456789'i64 == cast[int64](a)
 
+    test "Creation from binary strings":
+      block:
+        for i in 0..255:
+          let a = fmt"`{i:#b}'".parse(StInt[64], radix = 2)
+          let b = i.stint(64)
+
+          check: a == b
+          check: i.i64 == cast[int64](a)
+
+      block:
+        for i in 0..255:
+          let a = fmt"`{i:#b}'".parse(StUint[64], radix = 2)
+          let b = i.stiunt(64)
+
+          check: a == b
+          check: i.u64 == cast[uint64](a)
+
+      block:
+        let a = "0b1111111111111111".parse(StInt[16], 2)
+        let b = (-1'i16).stint(16)
+
+        check: a == b
+        check: -1'i16 == cast[int16](a)
+
+    test "Creation from octal strings":
+      block:
+        for i in 0..255:
+          let a = fmt"`{i:#o}'".parse(StInt[64], radix = 8)
+          let b = i.stint(64)
+
+          check: a == b
+          check: i.i64 == cast[int64](a)
+
+      block:
+        for i in 0..255:
+          let a = fmt"`{i:#o}'".parse(StUint[64], radix = 8)
+          let b = i.stiunt(64)
+
+          check: a == b
+          check: i.u64 == cast[uint64](a)
+
+      block:
+        let a = "0o177777".parse(StInt[16], 8)
+        let b = (-1'i16).stint(16)
+
+        check: a == b
+        check: -1'i16 == cast[int16](a)
+
     test "Creation from hex strings":
       block:
-        let a = "0xFF".parse(StInt[64], radix = 16)
-        let b = 255.stint(64)
+        for i in 0..255:
+          let a = fmt"`{i:#x}'".parse(StInt[64], radix = 16)
+          let aUppercase = fmt"`{i:#X}'".parse(StInt[64], radix = 16)
+          let b = i.stint(64)
 
-        check: a == b
-        check: 255'i64 == cast[int64](a)
+          check: a == aUppercase
+          check: a == b
+          check: i.i64 == cast[int64](a)
 
       block:
-        let a = "0xFF".parse(StUint[64], radix = 16)
-        let b = 255.stuint(64)
+        for i in 0..255:
+          let a = fmt"`{i:#x}'".parse(StUint[64], radix = 16)
+          let aUppercase = fmt"`{i:#X}'".parse(StUint[64], radix = 16)
+          let b = i.stiunt(64)
 
-        check: a == b
-        check: 255'u64 == cast[uint64](a)
+          check: a == aUppercase
+          check: a == b
+          check: i.u64 == cast[uint64](a)
 
-        let a2 = hexToUint[64]("0xFF")
-        check: a == a2
+          let a2 = hexToUint[64](fmt"`{i:#x}'")
+          let a3 = hexToUint[64](fmt"`{i:#X}'")
+          check: a == a2
+          check: a == a3
 
       block:
         let a = "0xFFFF".parse(StInt[16], 16)

--- a/tests/test_io.nim
+++ b/tests/test_io.nim
@@ -1097,7 +1097,7 @@ proc main() =
           let b = i.stint(64)
 
           check: a == b
-          check: i.i64 == cast[int64](a)
+          check: int64(i) == cast[int64](a)
 
       block:
         for i in 0..255:
@@ -1105,7 +1105,7 @@ proc main() =
           let b = i.stiunt(64)
 
           check: a == b
-          check: i.u64 == cast[uint64](a)
+          check: uint64(i) == cast[uint64](a)
 
       block:
         let a = "0b1111111111111111".parse(StInt[16], 2)
@@ -1121,7 +1121,7 @@ proc main() =
           let b = i.stint(64)
 
           check: a == b
-          check: i.i64 == cast[int64](a)
+          check: int64(i) == cast[int64](a)
 
       block:
         for i in 0..255:
@@ -1129,7 +1129,7 @@ proc main() =
           let b = i.stiunt(64)
 
           check: a == b
-          check: i.u64 == cast[uint64](a)
+          check: uint64(i) == cast[uint64](a)
 
       block:
         let a = "0o177777".parse(StInt[16], 8)
@@ -1147,7 +1147,7 @@ proc main() =
 
           check: a == aUppercase
           check: a == b
-          check: i.i64 == cast[int64](a)
+          check: int64(i) == cast[int64](a)
 
       block:
         for i in 0..255:
@@ -1157,7 +1157,7 @@ proc main() =
 
           check: a == aUppercase
           check: a == b
-          check: i.u64 == cast[uint64](a)
+          check: uint64(i) == cast[uint64](a)
 
           let a2 = hexToUint[64](fmt"`{i:#x}'")
           let a3 = hexToUint[64](fmt"`{i:#X}'")

--- a/tests/test_io.nim
+++ b/tests/test_io.nim
@@ -1093,7 +1093,7 @@ proc main() =
     test "Creation from binary strings":
       block:
         for i in 0..255:
-          let a = fmt"`{i:#b}'".parse(StInt[64], radix = 2)
+          let a = fmt("{i:#b}").parse(StInt[64], radix = 2)
           let b = i.stint(64)
 
           check: a == b
@@ -1101,7 +1101,7 @@ proc main() =
 
       block:
         for i in 0..255:
-          let a = fmt"`{i:#b}'".parse(StUint[64], radix = 2)
+          let a = fmt("{i:#b}").parse(StUint[64], radix = 2)
           let b = i.stuint(64)
 
           check: a == b
@@ -1117,7 +1117,7 @@ proc main() =
     test "Creation from octal strings":
       block:
         for i in 0..255:
-          let a = fmt"`{i:#o}'".parse(StInt[64], radix = 8)
+          let a = fmt("{i:#o}").parse(StInt[64], radix = 8)
           let b = i.stint(64)
 
           check: a == b
@@ -1125,7 +1125,7 @@ proc main() =
 
       block:
         for i in 0..255:
-          let a = fmt"`{i:#o}'".parse(StUint[64], radix = 8)
+          let a = fmt("{i:#o}").parse(StUint[64], radix = 8)
           let b = i.stuint(64)
 
           check: a == b
@@ -1141,8 +1141,8 @@ proc main() =
     test "Creation from hex strings":
       block:
         for i in 0..255:
-          let a = fmt"`{i:#x}'".parse(StInt[64], radix = 16)
-          let aUppercase = fmt"`{i:#X}'".parse(StInt[64], radix = 16)
+          let a = fmt("{i:#x}").parse(StInt[64], radix = 16)
+          let aUppercase = fmt("{i:#X}").parse(StInt[64], radix = 16)
           let b = i.stint(64)
 
           check: a == aUppercase
@@ -1151,16 +1151,16 @@ proc main() =
 
       block:
         for i in 0..255:
-          let a = fmt"`{i:#x}'".parse(StUint[64], radix = 16)
-          let aUppercase = fmt"`{i:#X}'".parse(StUint[64], radix = 16)
+          let a = fmt("{i:#x}").parse(StUint[64], radix = 16)
+          let aUppercase = fmt("{i:#X}").parse(StUint[64], radix = 16)
           let b = i.stuint(64)
 
           check: a == aUppercase
           check: a == b
           check: uint64(i) == cast[uint64](a)
 
-          let a2 = hexToUint[64](fmt"`{i:#x}'")
-          let a3 = hexToUint[64](fmt"`{i:#X}'")
+          let a2 = hexToUint[64](fmt("{i:#x}"))
+          let a3 = hexToUint[64](fmt("{i:#X}"))
           check: a == a2
           check: a == a3
 

--- a/tests/test_io.nim
+++ b/tests/test_io.nim
@@ -1171,6 +1171,14 @@ proc main() =
         check: a == b
         check: -1'i16 == cast[int16](a)
 
+      block:
+        let a = "0b1234abcdef".parse(StInt[16], 16)
+        let b = "0x0b1234abcdef".parse(StInt[16], 16)
+        let c = 0x0b1234abcdef.stint(64)
+
+        check: a == b
+        check: a == c
+        
     test "Conversion to decimal strings":
       block:
         let a = 1234567891234567890.stint(128)

--- a/tests/test_io.nim
+++ b/tests/test_io.nim
@@ -1102,7 +1102,7 @@ proc main() =
       block:
         for i in 0..255:
           let a = fmt"`{i:#b}'".parse(StUint[64], radix = 2)
-          let b = i.stiunt(64)
+          let b = i.stuint(64)
 
           check: a == b
           check: uint64(i) == cast[uint64](a)
@@ -1126,7 +1126,7 @@ proc main() =
       block:
         for i in 0..255:
           let a = fmt"`{i:#o}'".parse(StUint[64], radix = 8)
-          let b = i.stiunt(64)
+          let b = i.stuint(64)
 
           check: a == b
           check: uint64(i) == cast[uint64](a)
@@ -1153,7 +1153,7 @@ proc main() =
         for i in 0..255:
           let a = fmt"`{i:#x}'".parse(StUint[64], radix = 16)
           let aUppercase = fmt"`{i:#X}'".parse(StUint[64], radix = 16)
-          let b = i.stiunt(64)
+          let b = i.stuint(64)
 
           check: a == aUppercase
           check: a == b


### PR DESCRIPTION
Hex strings starting with `0b` would erroneously treated as binary numbers by `skipPrefixes`. 

An error should be raised only when `radix` is not 2 or 16, while the `0b` prefix should be skipped only when `radix = 2`.

Related issue https://github.com/status-im/nim-web3/issues/63.