### PR TITLE
fixes asm statement in `nimHasAsmSemSymbol` in the devel branch

### DIFF
--- a/stint/private/primitives/extended_precision_x86_64_gcc.nim
+++ b/stint/private/primitives/extended_precision_x86_64_gcc.nim
@@ -41,7 +41,7 @@ func div2n1n_128*(q, r: var uint64, n_hi, n_lo, d: uint64) {.inline.}=
   # 2. don't forget to dereference the var hidden pointer
   # 3. -
   # 4. no clobbered registers beside explicitly used RAX and RDX
-  when defined(cpp):
+  when defined(cpp) or defined(nimHasAsmSemSymbol):
     asm """
       divq %[divisor]
       :"=a" (`q`), "=d" (`r`)


### PR DESCRIPTION
In https://github.com/nim-lang/Nim/pull/24547, asm statements require no explicit dereference