### PR TITLE
Avoid index error when creating zero literal

### DIFF
--- a/stint/literals_stint.nim
+++ b/stint/literals_stint.nim
@@ -1,5 +1,5 @@
 # Stint
-# Copyright 2018 Status Research & Development GmbH
+# Copyright 2018-2025 Status Research & Development GmbH
 # Licensed under either of
 #
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
@@ -77,8 +77,8 @@ make_mixed_types_ops(`xor`, InputType, BothSigned, switchInputs = true)
 
 # Specialization / fast path for comparison to zero
 # Note system.nim has templates to transform > and >= into <= and <
-template mtoIsZero*{a == 0}(a: StUint or StInt): bool = a.isZero
-template mtoIsZero*{0 == a}(a: StUint or StInt): bool = a.isZero
+template mtoIsZeroL*{a == 0}(a: StUint or StInt): bool = a.isZero
+template mtoIsZeroR*{0 == a}(a: StUint or StInt): bool = a.isZero
 
 template mtoIsNeg*{a < 0}(a: StInt): bool = a.isNegative
 template mtoIsNegOrZero*{a <= 0}(a: StInt): bool = a.isZero or a.isNegative

--- a/stint/private/custom_literal.nim
+++ b/stint/private/custom_literal.nim
@@ -1,5 +1,5 @@
 # Stint
-# Copyright 2018-2023 Status Research & Development GmbH
+# Copyright 2018-2025 Status Research & Development GmbH
 # Licensed under either of
 #
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
@@ -25,7 +25,7 @@ func getRadix(s: static string): uint8 {.compileTime.} =
     return 16
 
 func stripPrefix(s: string): string {.compileTime.} =
-  if s[0] != '0':
+  if s.len < 2 or s[0] != '0':
     return s
   if s[1] in {'b', 'o', 'x'}:
     return s[2 .. ^1]

--- a/stint/private/custom_literal.nim
+++ b/stint/private/custom_literal.nim
@@ -8,16 +8,16 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 func getRadix(s: static string): uint8 {.compileTime.} =
-  # maybe have prefix
-  if s.len >= 2 and s[0] == '0':
-    if s[1] == 'b':
-      return 2
+  when s.len >= 2:  # Nim < 2.2: When using `if`: `Error: index 1 not in 0`
+    if s[0] == '0':
+      if s[1] == 'b':
+        return 2
 
-    if s[1] == 'o':
-      return 8
+      if s[1] == 'o':
+        return 8
 
-    if s[1] == 'x':
-      return 16
+      if s[1] == 'x':
+        return 16
 
   10
 

--- a/stint/private/custom_literal.nim
+++ b/stint/private/custom_literal.nim
@@ -8,21 +8,18 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 func getRadix(s: static string): uint8 {.compileTime.} =
-  if s.len <= 2:
-    return 10
+  # maybe have prefix
+  if s.len >= 2 and s[0] == '0':
+    if s[1] == 'b':
+      return 2
 
-  # maybe have prefix have prefix
-  if s[0] != '0':
-    return 10
+    if s[1] == 'o':
+      return 8
 
-  if s[1] == 'b':
-    return 2
+    if s[1] == 'x':
+      return 16
 
-  if s[1] == 'o':
-    return 8
-
-  if s[1] == 'x':
-    return 16
+  10
 
 func stripPrefix(s: string): string {.compileTime.} =
   if s.len < 2 or s[0] != '0':

--- a/tests/test_features.nim
+++ b/tests/test_features.nim
@@ -1,4 +1,5 @@
-# Copyright 2023 Status Research & Development GmbH
+# Stint
+# Copyright 2023-2025 Status Research & Development GmbH
 # Licensed under either of
 #
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
@@ -20,6 +21,7 @@ suite "new features":
       b = 0xabcdef0123456'u256
       c = -100'i128
       d = -50000'i256
+      e = 0'u256
 
     let
       x = 0b111100011'u128
@@ -32,6 +34,7 @@ suite "new features":
       b == 0xabcdef0123456.u256
       c == -100.i128
       d == -50000.i256
+      e == 0'u256
       x == 0b111100011.u128
       y == 0o777766666.u256
       z == UInt256.fromHex("0x1122334455667788991011121314151617181920aabbccddeeffb1b2b3b4b500")


### PR DESCRIPTION
Trying to use `0'u256` results in `Error: index 1 not in 0 .. 0` because the literal parsing function assumes min length 2 when the literal starts with a 0. Fix that incorrect assumption.