### PR TITLE
Use  `borrow` from intops 1.0.8 instead of `borrowingSub` and discarding the subtraction result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ dprint.json
 *.log
 htmldocs
 docs
+nimble.develop
+nimbledeps

--- a/config.nims
+++ b/config.nims
@@ -1,4 +1,4 @@
-# begin Nimble config (version 1)
-when fileExists("nimble.paths"):
+# begin Nimble config (version 2)
+when withDir(thisDir(), system.fileExists("nimble.paths")):
   include "nimble.paths"
 # end Nimble config

--- a/stint.nimble
+++ b/stint.nimble
@@ -11,7 +11,7 @@ skipDirs      = @["tests", "benchmarks"]
 # TODO test only requirements don't work: https://github.com/nim-lang/nimble/issues/482
 requires "nim >= 1.6.12",
          "stew >= 0.2.0",
-         "intops >= 1.0.7",
+         "https://github.com/vacp2p/nim-intops#feature/get_carry_get_borrow",
          "unittest2 >= 0.2.3"
 
 let nimc = getEnv("NIMC", "nim") # Which nim compiler to use

--- a/stint.nimble
+++ b/stint.nimble
@@ -11,7 +11,7 @@ skipDirs      = @["tests", "benchmarks"]
 # TODO test only requirements don't work: https://github.com/nim-lang/nimble/issues/482
 requires "nim >= 1.6.12",
          "stew >= 0.2.0",
-         "https://github.com/vacp2p/nim-intops#feature/get_carry_get_borrow",
+         "intops >= 1.0.8",
          "unittest2 >= 0.2.3"
 
 let nimc = getEnv("NIMC", "nim") # Which nim compiler to use

--- a/stint/uintops.nim
+++ b/stint/uintops.nim
@@ -85,7 +85,7 @@ func `<`*(a, b: StUint): bool {.inline.} =
   var diff: Word
   var borrow: bool
   for i in 0 ..< a.limbs.len:
-    (diff, borrow) = borrowingSub(a[i], b[i], borrow)
+    borrow = getBorrow(a[i], b[i], borrow)
   return borrow
 
 func `<=`*(a, b: StUint): bool {.inline.} =

--- a/stint/uintops.nim
+++ b/stint/uintops.nim
@@ -85,7 +85,7 @@ func `<`*(a, b: StUint): bool {.inline.} =
   var diff: Word
   var borrow: bool
   for i in 0 ..< a.limbs.len:
-    borrow = borrow(a[i], b[i], borrow)
+    borrow = sub.borrow(a[i], b[i], borrow)
   return borrow
 
 func `<=`*(a, b: StUint): bool {.inline.} =

--- a/stint/uintops.nim
+++ b/stint/uintops.nim
@@ -85,7 +85,7 @@ func `<`*(a, b: StUint): bool {.inline.} =
   var diff: Word
   var borrow: bool
   for i in 0 ..< a.limbs.len:
-    borrow = getBorrow(a[i], b[i], borrow)
+    borrow = borrow(a[i], b[i], borrow)
   return borrow
 
 func `<=`*(a, b: StUint): bool {.inline.} =


### PR DESCRIPTION
This is a draft PR that it to be merged after https://github.com/vacp2p/nim-intops/pull/27 is merged and intops 1.0.8 is released.