### PR TITLE
Bugfix: Fix `nimble test`

### DIFF
--- a/stint.nimble
+++ b/stint.nimble
@@ -38,7 +38,7 @@ proc test(path: string) =
   for config in ["", "-d:stintNoIntrinsics"]:
     for mode in ["-d:debug", "-d:release"]:
       # Compile-time tests are done separately to speed up full testing
-      run(config & " " & mode & " -d:unittest2Static=false", path)
+      run(config & " " & mode & " --skipParentCfg:off -d:unittest2Static=false", path)
 
 task test_internal, "Run tests for internal procs":
   test "tests/internal"

--- a/tests/config.nims
+++ b/tests/config.nims
@@ -1,2 +1,1 @@
-switch("warning", "BareExcept:off")
 switch("define", "unittest2Static")


### PR DESCRIPTION
`nimble test` won't work with locally installed dependencies because of `--skipParentCfg` in `cfg` passed in the .nimble file. The deps paths are injected with `config.nims` from the repo root, which _is_ a parent config relative to `tests` directory.